### PR TITLE
Change thread mode to CRITICAL in sync buffer setup

### DIFF
--- a/src/DirettaOutput.cpp
+++ b/src/DirettaOutput.cpp
@@ -748,7 +748,7 @@ bool DirettaOutput::configureDiretta(const AudioFormat& format) {
     // ===== SYNCBUFFER SETUP (SinHost order) =====
     std::cout << "[DirettaOutput] 1. Opening..." << std::endl;
     m_syncBuffer->open(
-        DIRETTA::Sync::THRED_MODE(5),
+        DIRETTA::Sync::THRED_MODE(DIRETTA::Sync::CRITICAL),
         ACQUA::Clock::MilliSeconds(100),
         0, "DirettaRenderer", 0, 0, 0, 0,
         DIRETTA::Sync::MSMODE_AUTO


### PR DESCRIPTION
FIX CPU 100%: Remove NOSLEEP4CORE flag to allow sleeping Old value: 5 = CRITICAL(1) + NOSLEEP4CORE(4) → busy-wait at 100% CPU New value: 1 = CRITICAL only → allows sleep() during sync Peut être cela impacte le son, mais on passe d'un thread à 100% à un thread à 2%