### PR TITLE
Fix race condition between audio callback and close()

### DIFF
--- a/src/DirettaRenderer.h
+++ b/src/DirettaRenderer.h
@@ -5,6 +5,8 @@
 #include <thread>
 #include <atomic>
 #include <mutex>
+#include <condition_variable>
+#include <iostream>
 
 // Forward declarations
 class UPnPDevice;
@@ -75,4 +77,19 @@ private:
     std::string m_currentMetadata;
     std::string m_nextURI;
     std::string m_nextMetadata;
+
+    // Callback synchronization - prevents race with close()
+    mutable std::mutex m_callbackMutex;
+    std::condition_variable m_callbackCV;
+    bool m_callbackRunning{false};
+
+    void waitForCallbackComplete() {
+        std::unique_lock<std::mutex> lk(m_callbackMutex);
+        bool completed = m_callbackCV.wait_for(lk, std::chrono::seconds(5),
+            [this]{ return !m_callbackRunning; });
+        if (!completed) {
+            std::cerr << "[DirettaRenderer] CRITICAL: Callback timeout!" << std::endl;
+            m_callbackRunning = false;
+        }
+    }
 };


### PR DESCRIPTION
Une nouvelle tentative de fix des races... Tu me dis si cela améliore... (du moi chez moi pas de regression sur mconnect ou hifi cast
Problem:
The audio callback was accessing DirettaOutput while the UPnP thread called close(), causing undefined behavior and potential crashes. The stopTimeMutex was also redundant since m_mutex already serializes UPnP callbacks.

Root cause analysis:
- Thread Audio: sendAudio(m_direttaOutput) concurrent with
- Thread UPnP: m_direttaOutput->close()
- No synchronization between callback execution and resource cleanup

Solution:
1. Add m_callbackMutex + condition_variable for callback/close sync
2. Callback checks state and sets running flag atomically with mutex
3. UPnP calls stop() with mutex held, then waits for callback completion
4. RAII guard (CallbackGuard) ensures flag cleanup on any exit path
5. 5-second timeout prevents infinite blocking on bugs

Simplification:
- Remove stopTimeMutex (redundant with m_mutex serialization)
- Keep DAC stabilization delay (hardware requirement, not race fix)

Safety improvement:
- Add decoder auto-reopen in process() as defensive safety net
- Handles edge case where decoder is null while state is PLAYING

Deadlock analysis:
- No deadlock possible: try_to_lock never blocks, CV wait releases mutex
- Audio thread never acquires m_mutex, breaking potential cycles

Files modified:
- DirettaRenderer.h: Add sync primitives and waitForCallbackComplete()
- DirettaRenderer.cpp: Sync in callback, onSetURI, onStop; remove stopTimeMutex
- AudioEngine.cpp: Safety net for null decoder recovery