### PR TITLE
Add port and name handling; switch CMD to array for safe argument pas…

### DIFF
--- a/systemd/diretta-renderer.conf
+++ b/systemd/diretta-renderer.conf
@@ -11,6 +11,9 @@
 # BASIC SETTINGS
 # ============================================================================
 
+# Renderer name (default: Diretta Renderer)
+NAME=""
+
 # Target Diretta device number (1 = first found)
 TARGET=1
 

--- a/systemd/start-renderer.sh
+++ b/systemd/start-renderer.sh
@@ -5,6 +5,7 @@
 set -e
 
 # Default values (can be overridden by config file)
+NAME="${NAME:-}"
 TARGET="${TARGET:-1}"
 PORT="${PORT:-4005}"
 BUFFER="${BUFFER:-2.0}"
@@ -17,56 +18,64 @@ CYCLE_MIN_TIME="${CYCLE_MIN_TIME:-}"
 INFO_CYCLE="${INFO_CYCLE:-}"
 MTU_OVERRIDE="${MTU_OVERRIDE:-}"
 
-RENDERER_BIN="/opt/diretta-renderer-upnp/DirettaRendererUPnP"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RENDERER_BIN="${SCRIPT_DIR}/DirettaRendererUPnP"
 
 # Build command with options
-CMD="$RENDERER_BIN"
+CMD=("$RENDERER_BIN")
+
+# Renderer name
+if [ -n "$NAME" ]; then
+    NAME="$(eval echo "$NAME")"
+    CMD+=( --name "$NAME" )
+fi
 
 # Basic options
-CMD="$CMD --target $TARGET"
-CMD="$CMD --buffer $BUFFER"
+CMD+=( --target "$TARGET" )
+CMD+=( --port "$PORT" )
+CMD+=( --buffer "$BUFFER" )
 
 # Network interface option (CRITICAL for multi-homed systems)
 if [ -n "$NETWORK_INTERFACE" ]; then
     # Check if it looks like an IP address or interface name
     if [[ "$NETWORK_INTERFACE" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         echo "Binding to IP address: $NETWORK_INTERFACE"
-        CMD="$CMD --bind-ip $NETWORK_INTERFACE"
+        CMD+=( --bind-ip "$NETWORK_INTERFACE" )
     else
         echo "Binding to network interface: $NETWORK_INTERFACE"
-        CMD="$CMD --interface $NETWORK_INTERFACE"
+        CMD+=( --interface "$NETWORK_INTERFACE" )
     fi
 fi
 
 # Gapless
 if [ -n "$GAPLESS" ]; then
-    CMD="$CMD $GAPLESS"
+    CMD+=( "$GAPLESS" )
 fi
 
 # Verbose
 if [ -n "$VERBOSE" ]; then
-    CMD="$CMD $VERBOSE"
+    CMD+=( "$VERBOSE" )
 fi
 
 # Advanced Diretta settings (only if specified)
 if [ -n "$THREAD_MODE" ]; then
-    CMD="$CMD --thread-mode $THREAD_MODE"
+    CMD+=( --thread-mode "$THREAD_MODE" )
 fi
 
 if [ -n "$CYCLE_TIME" ]; then
-    CMD="$CMD --cycle-time $CYCLE_TIME"
+    CMD+=( --cycle-time "$CYCLE_TIME" )
 fi
 
 if [ -n "$CYCLE_MIN_TIME" ]; then
-    CMD="$CMD --cycle-min-time $CYCLE_MIN_TIME"
+    CMD+=( --cycle-min-time "$CYCLE_MIN_TIME" )
 fi
 
 if [ -n "$INFO_CYCLE" ]; then
-    CMD="$CMD --info-cycle $INFO_CYCLE"
+    CMD+=( --info-cycle "$INFO_CYCLE" )
 fi
 
 if [ -n "$MTU_OVERRIDE" ]; then
-    CMD="$CMD --mtu $MTU_OVERRIDE"
+    CMD+=( --mtu "$MTU_OVERRIDE" )
 fi
 
 # Log the command being executed
@@ -76,14 +85,15 @@ echo "════════════════════════�
 echo ""
 echo "Configuration:"
 echo "  Target:           $TARGET"
+echo "  Port:             $PORT"
 echo "  Buffer:           $BUFFER seconds"
 echo "  Network Interface: ${NETWORK_INTERFACE:-auto-detect}"
 echo ""
 echo "Command:"
-echo "  $CMD"
+echo "  ${CMD[@]}"
 echo ""
 echo "════════════════════════════════════════════════════════"
 echo ""
 
 # Execute
-exec $CMD
+exec "${CMD[@]}"


### PR DESCRIPTION
Summary
- Added name and port handling to start-renderer.sh and diretta-renderer.conf
- Added name handling and enabled names containing spaces or shell variables
- Switched command construction from a single string to an array to ensure safe and correct argument passing

Motivation
- The previous implementation could not correctly handle renderer names that include spaces or variables
- Using an array for the command prevents unwanted word splitting and improves safety and reliability
- Adding explicit port and name handling makes the systemd integration more flexible and robust

Environment
- Tested on an Arch Linux x64v3 environment
