### PR TITLE
Fix detection of FFmpeg version and libavformat major version

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -735,6 +735,9 @@ check_ffmpeg_abi_compatibility() {
 
     # Get compile-time version from system headers
     local header_paths=(
+        "/usr/include/ffmpeg/libavformat/version.h"
+        "/usr/include/libavformat/version.h"
+        "/usr/local/include/libavformat/version.h"
         "/usr/include/ffmpeg/libavformat/version_major.h"
         "/usr/include/libavformat/version_major.h"
         "/usr/local/include/libavformat/version_major.h"

--- a/install.sh
+++ b/install.sh
@@ -723,7 +723,7 @@ check_ffmpeg_abi_compatibility() {
     # Get runtime version
     local runtime_ver=""
     if command -v ffmpeg &> /dev/null; then
-        runtime_ver=$(ffmpeg -version 2>&1 | head -1 | grep -oP 'ffmpeg version \K[0-9]+\.[0-9]+(\.[0-9]+)?' || echo "")
+        runtime_ver=$(ffmpeg -version 2>&1 | head -1 | grep -oP 'ffmpeg version n?\K[0-9]+\.[0-9]+(\.[0-9]+)?' || echo "")
     fi
 
     if [ -z "$runtime_ver" ]; then
@@ -735,9 +735,9 @@ check_ffmpeg_abi_compatibility() {
 
     # Get compile-time version from system headers
     local header_paths=(
-        "/usr/include/ffmpeg/libavformat/version.h"
-        "/usr/include/libavformat/version.h"
-        "/usr/local/include/libavformat/version.h"
+        "/usr/include/ffmpeg/libavformat/version_major.h"
+        "/usr/include/libavformat/version_major.h"
+        "/usr/local/include/libavformat/version_major.h"
     )
 
     local compile_major=""
@@ -784,7 +784,7 @@ check_ffmpeg_abi_compatibility() {
 detect_ffmpeg_runtime_version() {
     local runtime_ver=""
     if command -v ffmpeg &> /dev/null; then
-        runtime_ver=$(ffmpeg -version 2>&1 | head -1 | grep -oP 'ffmpeg version \K[0-9]+\.[0-9]+(\.[0-9]+)?' || echo "")
+        runtime_ver=$(ffmpeg -version 2>&1 | head -1 | grep -oP 'ffmpeg version n?\K[0-9]+\.[0-9]+(\.[0-9]+)?' || echo "")
     fi
     echo "$runtime_ver"
 }


### PR DESCRIPTION
Summary:

This PR improves the FFmpeg version detection logic in `install.sh` to handle various distribution packaging styles and maintain compatibility with newer FFmpeg releases.


Detailed Changes:
1. Handle optional 'n' prefix in runtime strings

According to [this commit](https://github.com/FFmpeg/FFmpeg/commit/f3158c3f29cd24cf50a02b58201ec2cf149b51e5), FFmpeg versions built from git tags or snapshots output strings like `ffmpeg version n8.1`. The previous regex strictly expected a digit, causing detection to fail on these builds.
  
2. Support for `version_major.h` 

In recent FFmpeg releases (starting from [this commit](https://github.com/FFmpeg/FFmpeg/commit/4eb9232c6ebfcee21dea4e9fd6a2deeda5115846)), the major version macros were moved from `version.h` to `version_major.h`.

To ensure this script works across both legacy and modern systems, I have updated the header_paths to search for both file variants.

Please check and confirm whether this PR can be merged. Thanks you!