### PR TITLE
Ensure the linker uses lld & Optimize compiler flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ else
     CXX = g++
     CC = gcc
 endif
-CXXFLAGS = -std=c++17 -Wall -Wextra -O2 -pthread
+CXXFLAGS = -std=c++17 -Wall -Wextra -O3 -pthread
 CFLAGS = -O3 -Wall
-LDFLAGS = -O2 -pthread
+LDFLAGS = -O3 -pthread
 ifdef LLVM
     CXXFLAGS += -flto
     CFLAGS += -flto

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ ifeq ($(DIRETTA_ARCH),x64)
     ifneq (,$(findstring zen4,$(FULL_VARIANT)))
         CXXFLAGS += -march=znver4 -mtune=znver4
         CFLAGS += -march=znver4 -mtune=znver4
+        LDFLAGS += -march=znver4 -mtune=znver4
         COMPILE_AVX2 = 1
         $(info Compiler: Zen4 microarchitecture optimization enabled)
 
@@ -110,6 +111,7 @@ ifeq ($(DIRETTA_ARCH),x64)
     else ifneq (,$(findstring v4,$(FULL_VARIANT)))
         CXXFLAGS += -march=x86-64-v4 -mavx512f -mavx512bw -mavx512vl -mavx512dq
         CFLAGS += -march=x86-64-v4 -mavx512f -mavx512bw -mavx512vl -mavx512dq
+        LDFLAGS += -march=x86-64-v4 -mavx512f -mavx512bw -mavx512vl -mavx512dq
         COMPILE_AVX2 = 1
         $(info Compiler: x86-64-v4 (AVX-512) optimization enabled)
 
@@ -117,6 +119,7 @@ ifeq ($(DIRETTA_ARCH),x64)
     else ifneq (,$(findstring v3,$(FULL_VARIANT)))
         CXXFLAGS += -march=x86-64-v3 -mavx2 -mfma
         CFLAGS += -march=x86-64-v3 -mavx2 -mfma
+        LDFLAGS += -march=x86-64-v3 -mavx2 -mfma
         COMPILE_AVX2 = 1
         $(info Compiler: x86-64-v3 (AVX2) optimization enabled)
 
@@ -124,6 +127,7 @@ ifeq ($(DIRETTA_ARCH),x64)
     else
         CXXFLAGS += -march=x86-64-v2
         CFLAGS += -march=x86-64-v2
+        LDFLAGS += -march=x86-64-v2
         COMPILE_AVX2 = 0
         $(info Compiler: x86-64-v2 (baseline, no AVX2) optimization enabled)
     endif
@@ -132,6 +136,7 @@ ifeq ($(DIRETTA_ARCH),x64)
 else ifeq ($(DIRETTA_ARCH),aarch64)
     CXXFLAGS += -mcpu=native
     CFLAGS += -mcpu=native
+    LDFLAGS += -mcpu=native
     $(info Compiler: ARM64 native CPU optimization enabled)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ else
 endif
 CXXFLAGS = -std=c++17 -Wall -Wextra -O2 -pthread
 CFLAGS = -O3 -Wall
-LDFLAGS = -pthread
+LDFLAGS = -O2 -pthread
 ifdef LLVM
     CXXFLAGS += -flto
     CFLAGS += -flto

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ LDFLAGS = -O3 -pthread
 ifdef LLVM
     CXXFLAGS += -flto
     CFLAGS += -flto
-    LDFLAGS += -flto
+    LDFLAGS += -flto -fuse-ld=lld
 endif
 
 # ============================================

--- a/install.sh
+++ b/install.sh
@@ -371,7 +371,7 @@ build_ffmpeg_8_minimal() {
     configure_opts=$(get_ffmpeg_8_minimal_opts | tr '\n' ' ')
 
     if [ -n "$LLVM" ]; then
-        extra_flags="$extra_flags --cc=clang --cxx=clang++ --enable-lto --extra-ldflags=-flto"
+        extra_flags="$extra_flags --cc=clang --cxx=clang++ --enable-lto --extra-ldflags=-flto --extra-ldflags=-fuse-ld=lld"
     fi
 
     # Run configure
@@ -449,7 +449,7 @@ build_ffmpeg_from_source() {
     fi
 
     if [ -n "$LLVM" ]; then
-        extra_flags="$extra_flags --cc=clang --cxx=clang++ --enable-lto --extra-ldflags=-flto"
+        extra_flags="$extra_flags --cc=clang --cxx=clang++ --enable-lto --extra-ldflags=-flto --extra-ldflags=-fuse-ld=lld"
     fi
 
     # Run configure


### PR DESCRIPTION
# Optimize LDFLAGS for LTO and unify optimization levels to -O3

## Description

This PR introduces optimizations to the build system's flags to ensure better performance and consistency, particularly when LTO is utilized.

The changes are categorized into three parts:

### 1. Synchronize LDFLAGS with Compiler Flags for LTO
When LTO is enabled, the linker handles the final code generation. To ensure it applies the correct architecture-specific optimizations and instruction scheduling, `LDFLAGS` now includes the same `-O` and `-march` flags used in compilation. This prevents the linker from falling back to generic instructions during the Whole Program Analysis phase.

### 2. Best Practice & Safety
For non-LTO builds, adding these flags to `LDFLAGS` is idempotent and harmless. This logic follows the standard behavior of modern build systems; for example, **CMake-generated Makefiles** (as seen in projects `slim2Diretta`) consistently propagate these flags to the linker to ensure build integrity.

### 3. Unified Optimization Level (-O3)
I noticed a discrepancy where `src/fastmemcpy-avx.c` used `-O3` while most `.cpp` files used `-O2`. To maintain performance consistency across the project, I have unified these to `-O3`.

> **Note:** If the use of `-O2` for C++ files was an intentional design choice (e.g., to avoid specific compiler regressions), please feel free to ignore or revert the final commit of this PR.

Thank you!