### PR TITLE
CPU affinity for the DirettaRenderer Audio thread (decode) + Bugfix NIC IRQ affinity

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1193,11 +1193,14 @@ setup_systemd_service() {
 set -e
 
 # Default values (can be overridden by config file)
+# v2.1.10: Aligned variable names with CLI (KEY → --key mapping)
+# Old names (RENDERER_NAME, NETWORK_INTERFACE, MTU_OVERRIDE) still supported as fallback
 TARGET="${TARGET:-1}"
 PORT="${PORT:-4005}"
 NAME="${NAME:-${RENDERER_NAME:-}}"
 GAPLESS="${GAPLESS:-}"
 VERBOSE="${VERBOSE:-}"
+MINIMAL_UPNP="${MINIMAL_UPNP:-}"
 INTERFACE="${INTERFACE:-${NETWORK_INTERFACE:-}}"
 THREAD_MODE="${THREAD_MODE:-}"
 CYCLE_TIME="${CYCLE_TIME:-}"
@@ -1206,6 +1209,20 @@ INFO_CYCLE="${INFO_CYCLE:-}"
 TRANSFER_MODE="${TRANSFER_MODE:-}"
 TARGET_PROFILE_LIMIT="${TARGET_PROFILE_LIMIT:-}"
 MTU="${MTU:-${MTU_OVERRIDE:-}}"
+
+# CPU affinity (no pinning by default). Accepts single core or comma-separated list.
+# Examples: CPU_AUDIO=3  or  CPU_AUDIO="3,4,5"
+CPU_AUDIO="${CPU_AUDIO:-}"
+CPU_DECODE="${CPU_DECODE:-}"
+CPU_OTHER="${CPU_OTHER:-}"
+
+# Buffer configuration (leave empty to use defaults)
+PCM_BUFFER_SECONDS="${PCM_BUFFER_SECONDS:-}"
+PCM_REMOTE_BUFFER_SECONDS="${PCM_REMOTE_BUFFER_SECONDS:-}"
+DSD_BUFFER_SECONDS="${DSD_BUFFER_SECONDS:-}"
+PCM_PREFILL_MS="${PCM_PREFILL_MS:-}"
+PCM_REMOTE_PREFILL_MS="${PCM_REMOTE_PREFILL_MS:-}"
+DSD_PREFILL_MS="${DSD_PREFILL_MS:-}"
 
 # Process priority defaults
 NICE_LEVEL="${NICE_LEVEL:--10}"
@@ -1327,6 +1344,11 @@ if [ -n "$VERBOSE" ]; then
     CMD+=($VERBOSE)
 fi
 
+# Minimal UPnP mode (no position polling, no events)
+if [ -n "$MINIMAL_UPNP" ] && [ "$MINIMAL_UPNP" = "1" ]; then
+    CMD+=("--minimal-upnp")
+fi
+
 # Advanced Diretta settings (only if specified)
 if [ -n "$THREAD_MODE" ]; then
     CMD+=("--thread-mode" "$THREAD_MODE")
@@ -1360,22 +1382,60 @@ if [ -n "$RT_PRIORITY" ] && [ "$RT_PRIORITY" != "50" ]; then
     CMD+=("--rt-priority" "$RT_PRIORITY")
 fi
 
+# CPU affinity
+if [ -n "$CPU_AUDIO" ]; then
+    CMD+=("--cpu-audio" "$CPU_AUDIO")
+fi
+
+if [ -n "$CPU_DECODE" ]; then
+    CMD+=("--cpu-decode" "$CPU_DECODE")
+fi
+
+if [ -n "$CPU_OTHER" ]; then
+    CMD+=("--cpu-other" "$CPU_OTHER")
+fi
+
+# Buffer configuration
+if [ -n "$PCM_BUFFER_SECONDS" ]; then
+    CMD+=("--pcm-buffer-seconds" "$PCM_BUFFER_SECONDS")
+fi
+if [ -n "$PCM_REMOTE_BUFFER_SECONDS" ]; then
+    CMD+=("--pcm-remote-buffer-seconds" "$PCM_REMOTE_BUFFER_SECONDS")
+fi
+if [ -n "$DSD_BUFFER_SECONDS" ]; then
+    CMD+=("--dsd-buffer-seconds" "$DSD_BUFFER_SECONDS")
+fi
+if [ -n "$PCM_PREFILL_MS" ]; then
+    CMD+=("--pcm-prefill-ms" "$PCM_PREFILL_MS")
+fi
+if [ -n "$PCM_REMOTE_PREFILL_MS" ]; then
+    CMD+=("--pcm-remote-prefill-ms" "$PCM_REMOTE_PREFILL_MS")
+fi
+if [ -n "$DSD_PREFILL_MS" ]; then
+    CMD+=("--dsd-prefill-ms" "$DSD_PREFILL_MS")
+fi
+
 # Build exec prefix as array for process priority
 EXEC_PREFIX=()
 
+# Apply nice level
 if [ -n "$NICE_LEVEL" ] && [ "$NICE_LEVEL" != "0" ]; then
     EXEC_PREFIX=("nice" "-n" "$NICE_LEVEL")
 fi
 
+# Apply I/O scheduling
 if [ -n "$IO_SCHED_CLASS" ]; then
+    # Map class name to ionice class number
     case "$IO_SCHED_CLASS" in
         realtime|1)  IONICE_CLASS=1 ;;
         best-effort|2) IONICE_CLASS=2 ;;
         idle|3)      IONICE_CLASS=3 ;;
         *)           IONICE_CLASS="" ;;
     esac
+
     if [ -n "$IONICE_CLASS" ]; then
         if [ "$IONICE_CLASS" = "3" ]; then
+            # idle class has no priority level
             EXEC_PREFIX=("ionice" "-c" "$IONICE_CLASS" "${EXEC_PREFIX[@]}")
         else
             EXEC_PREFIX=("ionice" "-c" "$IONICE_CLASS" "-n" "${IO_SCHED_PRIORITY:-0}" "${EXEC_PREFIX[@]}")
@@ -1442,7 +1502,7 @@ WRAPPER_EOF
         fi
 
         # Migrate settings from old config
-        local KNOWN_KEYS="TARGET PORT NAME RENDERER_NAME GAPLESS VERBOSE MINIMAL_UPNP INTERFACE NETWORK_INTERFACE THREAD_MODE CYCLE_TIME CYCLE_MIN_TIME INFO_CYCLE TRANSFER_MODE TARGET_PROFILE_LIMIT MTU MTU_OVERRIDE CPU_AUDIO CPU_OTHER PCM_BUFFER_SECONDS PCM_REMOTE_BUFFER_SECONDS DSD_BUFFER_SECONDS PCM_PREFILL_MS PCM_REMOTE_PREFILL_MS DSD_PREFILL_MS NICE_LEVEL IO_SCHED_CLASS IO_SCHED_PRIORITY RT_PRIORITY"
+        local KNOWN_KEYS="TARGET PORT NAME RENDERER_NAME GAPLESS VERBOSE MINIMAL_UPNP INTERFACE NETWORK_INTERFACE TARGET_INTERFACE TARGET_SPEED TARGET_DUPLEX THREAD_MODE CYCLE_TIME CYCLE_MIN_TIME INFO_CYCLE TRANSFER_MODE TARGET_PROFILE_LIMIT MTU MTU_OVERRIDE CPU_AUDIO CPU_DECODE CPU_OTHER PCM_BUFFER_SECONDS PCM_REMOTE_BUFFER_SECONDS DSD_BUFFER_SECONDS PCM_PREFILL_MS PCM_REMOTE_PREFILL_MS DSD_PREFILL_MS NICE_LEVEL IO_SCHED_CLASS IO_SCHED_PRIORITY RT_PRIORITY"
         local migrated_keys=""
         local obsolete_keys=""
 
@@ -1555,7 +1615,7 @@ SystemCallArchitectures=native
 SystemCallFilter=~@mount @keyring @debug @module @swap @reboot @obsolete
 
 # --- Performance ---
-# Nice and IOScheduling are configurable via /etc/default/diretta-renderer
+# Nice and IOScheduling are now configurable via /etc/default/diretta-renderer
 # (NICE_LEVEL, IO_SCHED_CLASS, IO_SCHED_PRIORITY) and applied by start-renderer.sh
 
 [Install]

--- a/install.sh
+++ b/install.sh
@@ -1594,7 +1594,7 @@ ReadWritePaths=/var/log
 
 # --- Device and kernel isolation ---
 PrivateDevices=true
-ProtectKernelTunables=true
+#ProtectKernelTunables=true -> removed so that the NIC IRQ affinity can be changed
 ProtectKernelModules=true
 ProtectKernelLogs=true
 ProtectControlGroups=true

--- a/src/DirettaRenderer.cpp
+++ b/src/DirettaRenderer.cpp
@@ -49,6 +49,26 @@ static std::vector<int> parseCoreList(const std::string& spec) {
     return cores;
 }
 
+// Sets SCHED_FIFO real-time priority (requires root on Linux)
+static bool setRealtimePriority(int priority = 51) {
+    struct sched_param param;
+    param.sched_priority = priority;
+
+    int ret = pthread_setschedparam(pthread_self(), SCHED_FIFO, &param);
+    if (ret != 0) {
+        // Not fatal - may not have CAP_SYS_NICE or running as non-root
+        if (g_verbose) {
+            std::cerr << "[Audio Thread] Warning: Could not set SCHED_FIFO priority "
+                      << priority << " (error " << ret << ")" << std::endl;
+        }    
+        return false;
+    }
+    if (g_verbose) {
+        std::cout << "[Audio Thread] Audio thread set to SCHED_FIFO priority " << priority << std::endl;
+    }
+    return true;
+}
+
 // Helper: pin current thread to one or more CPU cores.
 // When multiple cores are given, the kernel scheduler may move the thread
 // within that set. Returns true if pinning succeeded.
@@ -252,8 +272,10 @@ bool DirettaRenderer::start(std::atomic<bool>* stopSignal) {
                       << " us (" << (syncConfig.targetProfileLimitTime > 0 ? "TargetProfile" : "SelfProfile") << ")" << std::endl;
         if (!m_config.cpuAudio.empty())
             std::cout << "[DirettaRenderer] CPU audio (Diretta worker): core(s) " << m_config.cpuAudio << std::endl;
+        if (!m_config.cpuDecode.empty())
+            std::cout << "[DirettaRenderer] CPU decode (Audio decode): core(s) " << m_config.cpuDecode << std::endl;
         if (!m_config.cpuOther.empty())
-            std::cout << "[DirettaRenderer] CPU other (decode/UPnP): core(s) " << m_config.cpuOther << std::endl;
+            std::cout << "[DirettaRenderer] CPU other (UPnP/Position): core(s) " << m_config.cpuOther << std::endl;
         if (m_config.pcmBufferSeconds > 0)
             std::cout << "[DirettaRenderer] PCM buffer: " << m_config.pcmBufferSeconds << "s" << std::endl;
         if (m_config.pcmRemoteBufferSeconds > 0)
@@ -840,8 +862,14 @@ void DirettaRenderer::upnpThreadFunc() {
 }
 
 void DirettaRenderer::audioThreadFunc() {
-    auto cores = parseCoreList(m_config.cpuOther);
-    if (!cores.empty()) pinThreadToCores(cores, "Audio Thread");
+    auto cores = parseCoreList(m_config.cpuDecode);
+    if (!cores.empty()) {
+	    pinThreadToCores(cores, "Audio Thread");
+	    setRealtimePriority(g_rtPriority);
+    } else {
+        auto cores = parseCoreList(m_config.cpuOther);
+        if (!cores.empty()) pinThreadToCores(cores, "Audio Thread");
+    }
     DEBUG_LOG("[Audio Thread] Started");
 
     // Buffer-level flow control thresholds (like MPD's Delay() approach)

--- a/src/DirettaRenderer.h
+++ b/src/DirettaRenderer.h
@@ -45,7 +45,8 @@ public:
         // CPU affinity (empty = no pinning, default)
         // Accept one or more cores (comma-separated), e.g. "6" or "6,7,8"
         std::string cpuAudio;     // Cores for DirettaSync worker thread (critical hot path)
-        std::string cpuOther;     // Cores for other threads (UPnP, position, decode)
+        std::string cpuDecode;    // Cores for DirettaRenderer audio thread (decode)
+        std::string cpuOther;     // Cores for other threads (UPnP, position)
 
         // Buffer configuration (-1 = use defaults)
         float pcmBufferSeconds = -1.0f;        // Default 0.5s

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -249,6 +249,19 @@ DirettaRenderer::Config parseArguments(int argc, char* argv[]) {
                 }
             }
         }
+        else if (arg == "--cpu-decode" && i + 1 < argc) {
+            config.cpuDecode = argv[++i];
+            int numCores = static_cast<int>(sysconf(_SC_NPROCESSORS_ONLN));
+            auto cores = parseCoreSpec(config.cpuDecode);
+            for (int c : cores) {
+                if (c >= numCores) {
+                    std::cerr << "Warning: --cpu-decode contains invalid core " << c
+                              << " (this system has cores 0-" << (numCores - 1) << ")" << std::endl;
+                    config.cpuDecode.clear();
+                    break;
+                }
+            }
+        }
         else if (arg == "--cpu-other" && i + 1 < argc) {
             config.cpuOther = argv[++i];
             int numCores = static_cast<int>(sysconf(_SC_NPROCESSORS_ONLN));
@@ -313,7 +326,8 @@ DirettaRenderer::Config parseArguments(int argc, char* argv[]) {
                       << "\n"
                       << "CPU affinity (core isolation for audio quality):\n"
                       << "  --cpu-audio <cores>        Pin Diretta worker thread to CPU core(s), comma-separated (e.g., '3' or '3,4')\n"
-                      << "  --cpu-other <cores>        Pin other threads (decode/UPnP) to CPU core(s), comma-separated\n"
+                      << "  --cpu-decode <cores>       Pin DirettaRenderer Audio thread (decode) to CPU core(s), comma-separated\n"
+                      << "  --cpu-other <cores>        Pin other threads (UPnP/position) to CPU core(s), comma-separated\n"
                       << "\n"
                       << "Buffer configuration (advanced — leave unset to use defaults):\n"
                       << "  --pcm-buffer-seconds <s>       PCM local buffer size in seconds (default 0.5)\n"
@@ -390,11 +404,39 @@ int main(int argc, char* argv[]) {
                 if (a == o) {
                     std::cerr << "Warning: --cpu-audio and --cpu-other share core "
                               << a << ". Thread isolation may be reduced." << std::endl;
-                    goto skip_warn;
+                    goto skip_warn1;
                 }
             }
         }
-        skip_warn:;
+        skip_warn1:;
+    }
+    if (!config.cpuAudio.empty() && !config.cpuDecode.empty()) {
+        auto audioCores = parseCoreSpec(config.cpuAudio);
+        auto decodeCores = parseCoreSpec(config.cpuDecode);
+        for (int a : audioCores) {
+            for (int o : decodeCores) {
+                if (a == o) {
+                    std::cerr << "Warning: --cpu-audio and --cpu-decode share core "
+                              << a << ". Thread isolation may be reduced." << std::endl;
+                    goto skip_warn2;
+                }
+            }
+        }
+        skip_warn2:;
+    }
+    if (!config.cpuDecode.empty() && !config.cpuOther.empty()) {
+        auto decodeCores = parseCoreSpec(config.cpuDecode);
+        auto otherCores = parseCoreSpec(config.cpuOther);
+        for (int a : decodeCores) {
+            for (int o : otherCores) {
+                if (a == o) {
+                    std::cerr << "Warning: --cpu-decode and --cpu-other share core "
+                              << a << ". Thread isolation may be reduced." << std::endl;
+                    goto skip_warn3;
+                }
+            }
+        }
+        skip_warn3:;
     }
 
     // Pin main thread to cpuOther core(s) (keeps it off the audio core)

--- a/systemd/diretta-renderer.conf
+++ b/systemd/diretta-renderer.conf
@@ -228,7 +228,8 @@ IRQ_CPUS=""
 # jitter and improves soundstage clarity, especially on multi-core systems.
 #
 # CPU_AUDIO: Core(s) for the Diretta SDK sending thread (critical hot path)
-# CPU_OTHER: Core(s) for all other threads (decode, UPnP, position)
+# CPU_DECODE: Core(s) for the renderer decode thread (decode, ffmpeg)
+# CPU_OTHER: Core(s) for all other threads (UPnP, position)
 #
 # Each option accepts a single core or a comma-separated list:
 #   CPU_AUDIO=3              # single core
@@ -238,8 +239,9 @@ IRQ_CPUS=""
 # Use different cores for best results (e.g., CPU_AUDIO=2 CPU_OTHER="3,4,5").
 # Check available cores with: nproc  (or: lscpu)
 #
-# Example (isolate audio on core 2, everything else on cores 3-5):
+# Example (isolate audio on core 2, decode on core 1, everything else on cores 3-5):
 #CPU_AUDIO=2
+#CPU_DECODE=1
 #CPU_OTHER="3,4,5"
 
 # ----------------------------------------------------------------------------

--- a/systemd/diretta-renderer.service
+++ b/systemd/diretta-renderer.service
@@ -35,7 +35,7 @@ ReadWritePaths=/var/log
 
 # --- Device and kernel isolation ---
 PrivateDevices=true
-ProtectKernelTunables=true
+#ProtectKernelTunables=true -> removed so that the NIC IRQ affinity can be changed
 ProtectKernelModules=true
 ProtectKernelLogs=true
 ProtectControlGroups=true

--- a/systemd/start-renderer.sh
+++ b/systemd/start-renderer.sh
@@ -25,6 +25,7 @@ MTU="${MTU:-${MTU_OVERRIDE:-}}"
 # CPU affinity (no pinning by default). Accepts single core or comma-separated list.
 # Examples: CPU_AUDIO=3  or  CPU_AUDIO="3,4,5"
 CPU_AUDIO="${CPU_AUDIO:-}"
+CPU_DECODE="${CPU_DECODE:-}"
 CPU_OTHER="${CPU_OTHER:-}"
 
 # Buffer configuration (leave empty to use defaults)
@@ -196,6 +197,10 @@ fi
 # CPU affinity
 if [ -n "$CPU_AUDIO" ]; then
     CMD+=("--cpu-audio" "$CPU_AUDIO")
+fi
+
+if [ -n "$CPU_DECODE" ]; then
+    CMD+=("--cpu-decode" "$CPU_DECODE")
 fi
 
 if [ -n "$CPU_OTHER" ]; then

--- a/webui/profiles/diretta_renderer.json
+++ b/webui/profiles/diretta_renderer.json
@@ -138,6 +138,14 @@
                     "default": ""
                 },
                 {
+                    "key": "CPU_DECODE",
+                    "type": "number",
+                    "label": "Decode Core",
+                    "description": "Pin decode thread to CPU core(s). Single core or comma-separated list (e.g., '6,7,8'). Empty = no pinning.",
+                    "default": "",
+                    "min": 0
+                },
+                {
                     "key": "CPU_OTHER",
                     "type": "text",
                     "label": "Other Core(s)",

--- a/webui/profiles/diretta_renderer.json
+++ b/webui/profiles/diretta_renderer.json
@@ -139,11 +139,10 @@
                 },
                 {
                     "key": "CPU_DECODE",
-                    "type": "number",
-                    "label": "Decode Core",
+                    "type": "text",
+                    "label": "Decode Core(s)",
                     "description": "Pin decode thread to CPU core(s). Single core or comma-separated list (e.g., '6,7,8'). Empty = no pinning.",
-                    "default": "",
-                    "min": 0
+                    "default": ""
                 },
                 {
                     "key": "CPU_OTHER",

--- a/webui/profiles/diretta_renderer_minimal.json
+++ b/webui/profiles/diretta_renderer_minimal.json
@@ -88,11 +88,10 @@
                 },
                 {
                     "key": "CPU_DECODE",
-                    "type": "number",
-                    "label": "Decode Core",
+                    "type": "text",
+                    "label": "Decode Core(s)",
                     "description": "Pin decode thread to CPU core(s). Single core or comma-separated list (e.g., '6,7,8'). Empty = no pinning.",
-                    "default": "",
-                    "min": 0
+                    "default": ""
                 },
                 {
                     "key": "CPU_OTHER",

--- a/webui/profiles/diretta_renderer_minimal.json
+++ b/webui/profiles/diretta_renderer_minimal.json
@@ -87,6 +87,14 @@
                     "default": ""
                 },
                 {
+                    "key": "CPU_DECODE",
+                    "type": "number",
+                    "label": "Decode Core",
+                    "description": "Pin decode thread to CPU core(s). Single core or comma-separated list (e.g., '6,7,8'). Empty = no pinning.",
+                    "default": "",
+                    "min": 0
+                },
+                {
                     "key": "CPU_OTHER",
                     "type": "text",
                     "label": "Other Core(s)",


### PR DESCRIPTION
Added a option to change the CPU affinity of the DirettaRenderer audio thread. Receiving and decoding the stream should run on a dedicated core, separate from the UPnP, position and logging threads.
Removed #ProtectKernelTunables=true in diretta-renderer.service so that the NIC IRQ affinity can be changed.