### PR TITLE
fix: clean shutdown on corrupt PCM packet from radio stream

### DIFF
--- a/src/AudioEngine.cpp
+++ b/src/AudioEngine.cpp
@@ -95,6 +95,7 @@ AudioDecoder::~AudioDecoder() {
 
 bool AudioDecoder::open(const std::string& url) {
     std::cout << "[AudioDecoder] Opening: " << url.substr(0, 80) << "..." << std::endl;
+    m_decodeError = false;
 
     // Open input file
     m_formatContext = avformat_alloc_context();
@@ -1379,6 +1380,11 @@ size_t AudioDecoder::readSamples(AudioBuffer& buffer, size_t numSamples,
             } else if (ret < 0) {
                 std::cerr << "[AudioDecoder] Error receiving frame from decoder" << std::endl;
                 av_frame_unref(m_frame);
+                // Mark fatal decode error. Unlike m_eof this flag is set even when
+                // totalSamplesRead > 0 (corrupt packet after partial successful read).
+                // AudioEngine::process() checks AudioDecoder::hasDecodeError() and
+                // triggers a clean stop matching the normal EOF path.
+                m_decodeError = true;
                 return totalSamplesRead;
             }
 
@@ -2170,6 +2176,28 @@ bool AudioEngine::process(size_t samplesNeeded) {
         }
 
         m_samplesPlayed += samplesRead;
+    }
+
+    // Detect fatal decoder error: avcodec_receive_frame() failed on a corrupt packet.
+    // This check must happen BEFORE the samplesRead == 0 check because the error can
+    // occur after some samples were already decoded in the same readSamples() call,
+    // meaning samplesRead > 0 while the decoder is nonetheless unrecoverable.
+    // Example: "Invalid PCM packet" from a radio stream sets AudioDecoder::m_decodeError
+    // even when partial samples were returned.
+    // Mirror the normal EOF path exactly (see m_silenceCount > 5 block below):
+    // set m_state = STOPPED first, then call m_trackEndCallback(). This ensures
+    // the UPnP controller sees the correct state before the callback fires,
+    // which is what Roon needs to transition from STOPPED to ready-to-play.
+    if (m_currentDecoder && m_currentDecoder->hasDecodeError()) {
+        std::cerr << "[AudioEngine] Fatal decoder error (corrupt packet), "
+                  << "triggering clean stop" << std::endl;
+        m_silenceCount = 0;
+        m_isDraining = false;
+        m_state = State::STOPPED;
+        if (m_trackEndCallback) {
+            m_trackEndCallback();
+        }
+        return false;
     }
 
     // Check for actual end of data (no more samples can be read)

--- a/src/AudioEngine.cpp
+++ b/src/AudioEngine.cpp
@@ -1380,10 +1380,7 @@ size_t AudioDecoder::readSamples(AudioBuffer& buffer, size_t numSamples,
             } else if (ret < 0) {
                 std::cerr << "[AudioDecoder] Error receiving frame from decoder" << std::endl;
                 av_frame_unref(m_frame);
-                // Mark fatal decode error. Unlike m_eof this flag is set even when
-                // totalSamplesRead > 0 (corrupt packet after partial successful read).
-                // AudioEngine::process() checks AudioDecoder::hasDecodeError() and
-                // triggers a clean stop matching the normal EOF path.
+                // Set even when totalSamplesRead > 0 (error after partial read), unlike m_eof.
                 m_decodeError = true;
                 return totalSamplesRead;
             }
@@ -2178,21 +2175,21 @@ bool AudioEngine::process(size_t samplesNeeded) {
         m_samplesPlayed += samplesRead;
     }
 
-    // Detect fatal decoder error: avcodec_receive_frame() failed on a corrupt packet.
-    // This check must happen BEFORE the samplesRead == 0 check because the error can
-    // occur after some samples were already decoded in the same readSamples() call,
-    // meaning samplesRead > 0 while the decoder is nonetheless unrecoverable.
-    // Example: "Invalid PCM packet" from a radio stream sets AudioDecoder::m_decodeError
-    // even when partial samples were returned.
-    // Mirror the normal EOF path exactly (see m_silenceCount > 5 block below):
-    // set m_state = STOPPED first, then call m_trackEndCallback(). This ensures
-    // the UPnP controller sees the correct state before the callback fires,
-    // which is what Roon needs to transition from STOPPED to ready-to-play.
+    // Check before samplesRead == 0: error can occur after a partial read (samplesRead > 0).
     if (m_currentDecoder && m_currentDecoder->hasDecodeError()) {
-        std::cerr << "[AudioEngine] Fatal decoder error (corrupt packet), "
-                  << "triggering clean stop" << std::endl;
+        std::cerr << "[AudioEngine] Fatal decoder error (corrupt packet), triggering clean stop" << std::endl;
         m_silenceCount = 0;
         m_isDraining = false;
+        if (m_preloadRunning.load(std::memory_order_acquire)) {
+            lock.unlock();
+            waitForPreloadThread();
+            lock.lock();
+        }
+        m_nextDecoder.reset();
+        m_nextURI.clear();
+        m_nextMetadata.clear();
+        m_formatChangePending = false;
+        m_currentDecoder.reset();
         m_state = State::STOPPED;
         if (m_trackEndCallback) {
             m_trackEndCallback();

--- a/src/AudioEngine.h
+++ b/src/AudioEngine.h
@@ -117,6 +117,16 @@ public:
     bool isEOF() const { return m_eof; }
 
     /**
+     * @brief Check if a fatal decode error occurred (distinct from normal EOF).
+     * Set when avcodec_receive_frame() fails on a corrupt packet. Unlike isEOF(),
+     * this can be true even when readSamples() returned a non-zero count, because
+     * the error may occur after some samples were already successfully decoded in
+     * the same call. Read by AudioEngine::process() to trigger a clean stop.
+     * @return true if a fatal decode error was detected
+     */
+    bool hasDecodeError() const { return m_decodeError; }
+
+    /**
      * @brief Seek to a specific position in the audio file
      * @param seconds Position in seconds
      * @return true if successful, false otherwise
@@ -130,6 +140,7 @@ private:
     int m_audioStreamIndex;
     TrackInfo m_trackInfo;
     bool m_eof;
+    bool m_decodeError = false;  // Set on avcodec_receive_frame() failure (not EAGAIN/EOF)
 
     // DSD Native Mode
     bool m_rawDSD;           // True if reading raw DSD packets (no decoding)

--- a/src/AudioEngine.h
+++ b/src/AudioEngine.h
@@ -117,11 +117,7 @@ public:
     bool isEOF() const { return m_eof; }
 
     /**
-     * @brief Check if a fatal decode error occurred (distinct from normal EOF).
-     * Set when avcodec_receive_frame() fails on a corrupt packet. Unlike isEOF(),
-     * this can be true even when readSamples() returned a non-zero count, because
-     * the error may occur after some samples were already successfully decoded in
-     * the same call. Read by AudioEngine::process() to trigger a clean stop.
+     * @brief True if avcodec_receive_frame() failed on a corrupt packet (distinct from EOF).
      * @return true if a fatal decode error was detected
      */
     bool hasDecodeError() const { return m_decodeError; }


### PR DESCRIPTION
# Fix: Clean shutdown on corrupt PCM packet from radio stream

## Problem

When streaming internet radio, the renderer could receive a corrupt packet from
the server (FFmpeg reports `Invalid PCM packet, data has size 1 but at least a
size of 6 was expected`). This left the renderer in a zombie state:

- The audio thread continued running as if playback was active
- The Diretta target was not released
- The Diretta Link LEDs kept blinking at full rate
- Roon's playing timer kept counting
- No UPnP STOPPED event was sent to the control point

The only recovery was a manual `Ctrl+C`.

## Root cause

The corrupt packet error occurs inside `avcodec_receive_frame()`, which returns
a negative error code without setting `AVERROR_EOF`. This means `AudioDecoder::m_eof`
is never set to `true`.

Crucially, the error can occur **after** some samples have already been decoded
in the same `readSamples()` call, so `totalSamplesRead > 0`. This means the
existing `if (samplesRead == 0)` block in `AudioEngine::process()` — which
handles normal EOF — is never reached, and the renderer gets stuck.

This is distinct from the `Packet corrupt (dts = NOPTS)` error, which occurs at
the demuxer level (`av_read_frame()`), sets `m_eof = true` via `AVERROR_EOF`,
and was already handled correctly by the existing EOF flow.

## Fix

Two small additions, both in `AudioEngine`:

**`AudioEngine.h` — `AudioDecoder` class:**
- Added `bool m_decodeError` flag, cleared in `open()` and set in `readSamples()`
  when `avcodec_receive_frame()` returns a fatal error
- Added `bool hasDecodeError()` accessor

**`AudioEngine.cpp` — `AudioEngine::process()`:**
- Added a check for `m_currentDecoder->hasDecodeError()` **before** the
  `samplesRead == 0` block, so it catches the error even when partial samples
  were returned
- When detected, mirrors the existing normal EOF path exactly:
  sets `m_state = STOPPED`, then calls `m_trackEndCallback()`
- This triggers the same clean shutdown sequence as a normal track end:
  `stopPlayback()` → `release()` → `notifyStateChange("STOPPED")`

`DirettaRenderer.cpp` is **not modified**.

## Test results

Tested on Raspberry Pi 4 running GentooPlayer, streaming Sveriges Radio P2
(internet radio, PCM 44100Hz/24bit). The `Invalid PCM packet` error occurred
naturally during extended listening sessions.

**Before fix:** renderer entered zombie state, Diretta LEDs kept blinking,
Roon playing timer kept counting, manual restart required.

**After fix:**
```
[AudioDecoder] Error receiving frame from decoder
[AudioEngine] Fatal decoder error (corrupt packet), triggering clean stop
[DirettaSync] Session had 1 underrun(s)
```
- Diretta LEDs stopped immediately ✅
- Roon playing timer stopped ✅
- Diretta target released cleanly ✅
- UPnP STOPPED state sent to control point ✅
- Renderer continues running and accepts new play commands ✅

## Known limitation

After this error, Roon displays a Stop button instead of a Play button. Clicking
Stop once transitions Roon to the ready-to-play state. This is consistent with
UPnP STOPPED semantics for a radio stream with no next track queued, and matches
the behaviour of other stream-end scenarios. The control point (slim2UPnP) still
has an open HTTP connection at the time of the error, which causes the slight
state discrepancy. This is considered acceptable behaviour for a PR and is left
for future improvement if desired.

## Files changed

- `src/AudioEngine.h` — added `m_decodeError` flag and `hasDecodeError()` to `AudioDecoder`
- `src/AudioEngine.cpp` — added decoder error detection in `AudioEngine::process()`
  and `AudioDecoder::open()`
