### PR TITLE
fix: clean stop on live radio stream stall via local proxy (v2.5.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.5.1] - 2026-05-24
+
+### Fixed
+- **Permanent hang on live radio stream stall via Roon proxy** (reported by hoorna/Alfred for Mother Earth Radio Classic via Roon): When Roon serves an internet radio station via its local HTTP proxy, the TCP connection stays alive (keepalives) even when the upstream CDN or station stops sending audio. `av_read_frame()` blocks indefinitely on such a connection — the existing 30-second FFmpeg I/O timeout does not fire because TCP keepalives prevent a socket-level timeout. The ring buffer empties, `getNewStream()` enters rebuffering mode, and the renderer never recovers: Diretta Link LEDs keep blinking, the Roon playing-time counter runs on, and no UPnP command has any effect. The fix registers an `AVIOInterruptCB` on the `AVFormatContext` before `avformat_open_input()`. In each `readSamples()` call, a per-call deadline (`now + 20 s`) is written to an atomic before `av_read_frame()` and cleared to zero after it returns. The callback checks the deadline on every FFmpeg I/O poll; when `now >= deadline` it returns 1, causing `av_read_frame()` to abort with `AVERROR_EXIT`. A new `m_readTimeout` flag (analogous to v2.4.5's `m_decodeError`) is set, and `process()` detects it before the `samplesRead == 0` guard and triggers an immediate clean stop: preload thread joined, next-track state cleared, `m_state = STOPPED`, `m_trackEndCallback()` fired. The UPnP controller (Roon) receives the correct STOPPED state, the playing-time counter freezes, and the Diretta target is fully released — identical observable behaviour to the v2.4.5 corrupt-packet fix. The interrupt callback is zero-cost during normal playback (deadline is 0, first branch returns immediately). The `triggerFatalStop` lambda in `process()` is shared between the decode-error and read-timeout cases, eliminating the duplicate 14-line teardown.
+
 ## [2.5.0] - 2026-05-23
 
 ### Added

--- a/src/AudioEngine.cpp
+++ b/src/AudioEngine.cpp
@@ -7,6 +7,7 @@
 #include "DirettaRingBuffer.h"  // For kBitReverseLUT
 #include <iostream>
 #include <thread>
+#include <chrono>
 #include <cstring>
 #include <algorithm>
 #include "memcpyfast_audio.h"
@@ -93,9 +94,19 @@ AudioDecoder::~AudioDecoder() {
     close();
 }
 
+int AudioDecoder::ffmpegReadInterruptCb(void* opaque) {
+    auto* self = static_cast<AudioDecoder*>(opaque);
+    int64_t deadline = self->m_readDeadlineNs.load(std::memory_order_relaxed);
+    if (deadline == 0) return 0;
+    int64_t now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count();
+    return (now >= deadline) ? 1 : 0;
+}
+
 bool AudioDecoder::open(const std::string& url) {
     std::cout << "[AudioDecoder] Opening: " << url.substr(0, 80) << "..." << std::endl;
     m_decodeError = false;
+    m_readTimeout = false;
 
     // Open input file
     m_formatContext = avformat_alloc_context();
@@ -103,6 +114,10 @@ bool AudioDecoder::open(const std::string& url) {
         std::cerr << "[AudioDecoder] Failed to allocate format context" << std::endl;
         return false;
     }
+    // Register interrupt callback so av_read_frame() can be aborted externally
+    // (e.g., when a live stream via Roon proxy stalls without closing the TCP connection)
+    m_formatContext->interrupt_callback.callback = ffmpegReadInterruptCb;
+    m_formatContext->interrupt_callback.opaque = this;
 
     // ═══════════════════════════════════════════════════════════
     // DFF/DSDIFF: Use custom parser (FFmpeg has no DSDIFF demuxer)
@@ -1021,7 +1036,7 @@ size_t AudioDecoder::readSamples(AudioBuffer& buffer, size_t numSamples,
     // ══════════════════════════════════════════════════════════════
 
     if (m_rawDSD) {
-        if (m_eof) {
+        if (m_eof || m_readTimeout) {
             return 0;
         }
 
@@ -1165,8 +1180,14 @@ size_t AudioDecoder::readSamples(AudioBuffer& buffer, size_t numSamples,
 
             // Read packets until we have enough data
             // DSF layout: each packet is [blockSize L][blockSize R]
-            while (leftOffset < bytesPerChannelNeeded && !m_eof) {
+            while (leftOffset < bytesPerChannelNeeded && !m_eof && !m_readTimeout) {
+                // Deadline: abort if av_read_frame() blocks > 20s (live stream proxy stall)
+                m_readDeadlineNs.store(
+                    std::chrono::duration_cast<std::chrono::nanoseconds>(
+                        (std::chrono::steady_clock::now() + std::chrono::seconds(READ_STALL_TIMEOUT_S)).time_since_epoch()
+                    ).count(), std::memory_order_relaxed);
                 int ret = av_read_frame(m_formatContext, m_packet);
+                m_readDeadlineNs.store(0, std::memory_order_relaxed);
                 if (ret < 0) {
                     if (ret == AVERROR_EOF) {
                         m_eof = true;
@@ -1178,8 +1199,8 @@ size_t AudioDecoder::readSamples(AudioBuffer& buffer, size_t numSamples,
                         std::cerr << "[AudioDecoder] DSD: Connection reset by server" << std::endl;
                         m_eof = true;
                     } else if (ret == AVERROR_EXIT) {
-                        std::cerr << "[AudioDecoder] DSD: Exit requested" << std::endl;
-                        m_eof = true;
+                        std::cerr << "[AudioDecoder] DSD: Read timeout — stream stalled (live proxy?)" << std::endl;
+                        m_readTimeout = true;
                     } else {
                         char errbuf[AV_ERROR_MAX_STRING_SIZE];
                         av_strerror(ret, errbuf, sizeof(errbuf));
@@ -1265,7 +1286,7 @@ size_t AudioDecoder::readSamples(AudioBuffer& buffer, size_t numSamples,
     // PCM MODE - Normal decoding with resampling
     // ══════════════════════════════════════════════════════════════
 
-    if (!m_codecContext || m_eof) {
+    if (!m_codecContext || m_eof || m_readTimeout) {
         return 0;
     }
 
@@ -1327,9 +1348,15 @@ size_t AudioDecoder::readSamples(AudioBuffer& buffer, size_t numSamples,
         return totalSamplesRead; // Retourner ce qu'on a déjà lu du buffer
     }
 
-    while (totalSamplesRead < numSamples && !m_eof) {
-        // Read packet
+    while (totalSamplesRead < numSamples && !m_eof && !m_readTimeout) {
+        // Read packet — set 20s deadline so av_read_frame() cannot block indefinitely
+        // (protects against live streams via proxy keeping TCP alive with no audio data)
+        m_readDeadlineNs.store(
+            std::chrono::duration_cast<std::chrono::nanoseconds>(
+                (std::chrono::steady_clock::now() + std::chrono::seconds(READ_STALL_TIMEOUT_S)).time_since_epoch()
+            ).count(), std::memory_order_relaxed);
         int ret = av_read_frame(m_formatContext, m_packet);
+        m_readDeadlineNs.store(0, std::memory_order_relaxed);
 
         if (ret < 0) {
             // Log position when EOF occurs
@@ -1351,8 +1378,8 @@ size_t AudioDecoder::readSamples(AudioBuffer& buffer, size_t numSamples,
                 std::cerr << "[AudioDecoder] Connection reset by server" << std::endl;
                 m_eof = true;
             } else if (ret == AVERROR_EXIT) {
-                std::cerr << "[AudioDecoder] Exit requested" << std::endl;
-                m_eof = true;
+                std::cerr << "[AudioDecoder] Read timeout — stream stalled (live proxy?)" << std::endl;
+                m_readTimeout = true;
             } else if (ret == AVERROR(EIO) && bytesRead > 0) {
                 // HTTP stream closed mid-chunk without Content-Length.
                 // FFmpeg reports "Stream ends prematurely" because total size
@@ -2189,9 +2216,11 @@ bool AudioEngine::process(size_t samplesNeeded) {
         m_samplesPlayed += samplesRead;
     }
 
-    // Check before samplesRead == 0: error can occur after a partial read (samplesRead > 0).
-    if (m_currentDecoder && m_currentDecoder->hasDecodeError()) {
-        std::cerr << "[AudioEngine] Fatal decoder error (corrupt packet), triggering clean stop" << std::endl;
+    // Fatal decoder conditions checked before samplesRead == 0 because an error
+    // can occur after a partial read (samplesRead > 0). Both trigger an immediate
+    // clean stop without drain delay — mirrors v2.4.5 teardown ordering.
+    auto triggerFatalStop = [&](const char* reason) {
+        std::cerr << "[AudioEngine] " << reason << std::endl;
         m_silenceCount = 0;
         m_isDraining = false;
         if (m_preloadRunning.load(std::memory_order_acquire)) {
@@ -2208,6 +2237,16 @@ bool AudioEngine::process(size_t samplesNeeded) {
         if (m_trackEndCallback) {
             m_trackEndCallback();
         }
+    };
+
+    if (m_currentDecoder && m_currentDecoder->hasDecodeError()) {
+        triggerFatalStop("Fatal decoder error (corrupt packet), triggering clean stop");
+        return false;
+    }
+
+    // Live stream stall: av_read_frame() hit the 20s interrupt deadline (v2.5.1).
+    if (m_currentDecoder && m_currentDecoder->hasReadTimeout()) {
+        triggerFatalStop("Stream read timeout (live proxy stall), triggering clean stop");
         return false;
     }
 

--- a/src/AudioEngine.h
+++ b/src/AudioEngine.h
@@ -123,6 +123,12 @@ public:
     bool hasDecodeError() const { return m_decodeError; }
 
     /**
+     * @brief True if av_read_frame() was aborted by the interrupt callback (stream stall).
+     * Distinct from EOF — indicates the source stopped delivering data (e.g. live proxy stall).
+     */
+    bool hasReadTimeout() const { return m_readTimeout; }
+
+    /**
      * @brief Seek to a specific position in the audio file
      * @param seconds Position in seconds
      * @return true if successful, false otherwise
@@ -137,6 +143,7 @@ private:
     TrackInfo m_trackInfo;
     bool m_eof;
     bool m_decodeError = false;  // Set on avcodec_receive_frame() failure (not EAGAIN/EOF)
+    bool m_readTimeout = false;  // Set when av_read_frame() aborted by interrupt callback
 
     // DSD Native Mode
     bool m_rawDSD;           // True if reading raw DSD packets (no decoding)
@@ -180,6 +187,12 @@ private:
     AudioBuffer m_dsdRightBuffer;
     size_t m_dsdBufferCapacity = 0;
 
+    // FFmpeg interrupt callback: abort av_read_frame() if it stalls > 20s
+    // Prevents permanent hang when a live stream (e.g., Roon-proxied radio)
+    // keeps the HTTP connection alive but sends no audio data.
+    std::atomic<int64_t> m_readDeadlineNs{0};  // nanoseconds since epoch; 0 = no deadline
+    static int ffmpegReadInterruptCb(void* opaque);
+
     // Debug/diagnostic counters (instance variables, NOT static!)
     // These were previously static variables causing race conditions when
     // multiple AudioDecoder instances run concurrently (e.g., gapless preload)
@@ -197,6 +210,7 @@ private:
     int64_t m_cachedResamplerDelay = 0;
     int m_delayRefreshCounter = 0;
     static constexpr int DELAY_REFRESH_INTERVAL = 100;  // Refresh every 100 frames
+    static constexpr int READ_STALL_TIMEOUT_S = 20;     // Abort av_read_frame() after this many seconds
 
     bool initResampler(uint32_t outputRate, uint32_t outputBits);
     bool canBypass(uint32_t outputRate, uint32_t outputBits) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@
 #include <cerrno>
 #include <cstring>
 
-#define RENDERER_VERSION "2.5.0"
+#define RENDERER_VERSION "2.5.1"
 #define RENDERER_BUILD_DATE __DATE__
 #define RENDERER_BUILD_TIME __TIME__
 


### PR DESCRIPTION
## Problem

When playing internet radio via Roon (which proxies the station through a local HTTP URL), the renderer hangs permanently after a buffer underrun if the upstream station stops sending audio.

Roon's proxy keeps the TCP connection alive with keepalives, so `av_read_frame()` blocks indefinitely — the existing FFmpeg I/O timeout does not fire because there is no socket-level timeout. The ring buffer stays empty, `getNewStream()` stays in rebuffering mode, the Diretta Link LEDs keep blinking, and the Roon playing-time counter keeps running. No UPnP command has any effect.

## Root cause

`av_read_frame()` has no way to be interrupted from outside once it is blocking. FFmpeg's `AVIOInterruptCB` mechanism exists precisely for this: it is polled periodically during blocking I/O and aborts with `AVERROR_EXIT` when it returns 1.

## Fix

- Register an `AVIOInterruptCB` on the `AVFormatContext` before `avformat_open_input()`
- In each `readSamples()` call, write a deadline (`now + 20s`) to an atomic before `av_read_frame()` and clear it after — zero-cost during normal playback (deadline == 0, first branch returns immediately)
- On `AVERROR_EXIT`, set `m_readTimeout = true` (mirrors v2.4.5 `m_decodeError`)
- In `process()`, detect `hasReadTimeout()` before the `samplesRead == 0` guard and trigger an immediate clean stop via the shared `triggerFatalStop` lambda (also used for `hasDecodeError()`)
- Teardown order: preload thread joined → next-track state cleared → `state = STOPPED` → `m_trackEndCallback()` — identical to v2.4.5

## Design

Follows the v2.4.5 corrupt-packet fix (PR #72) exactly: separate flag, reset in `open()`, accessor method, immediate teardown in `process()`, state set before callback, no drain delay. The `triggerFatalStop` lambda eliminates the duplicate 14-line teardown that would otherwise exist for both fatal conditions.

## Test

Reproduced with Mother Earth Radio Classic via Roon on a buffer underrun (~30 min playback). After the fix:
- At t+18s after underrun: `[AudioDecoder] Read timeout — stream stalled (live proxy?)`
- Immediate clean stop: Diretta target released, Roon playing-time counter freezes, stop button visible
- No hang, no blinking LEDs

Observable result is identical to the v2.4.5 corrupt-packet fix.