### PR TITLE
fix(webui): dedup config saves, preserve commented example lines

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1557,9 +1557,14 @@ WRAPPER_EOF
 
                 # Check if this key is known in current version
                 if echo "$KNOWN_KEYS" | grep -qw "$key"; then
-                    # Apply to new config: replace commented or uncommented line
+                    # Apply to new config: replace only the FIRST occurrence of
+                    # the key (commented or uncommented). The 0,/pattern/ range
+                    # limits the substitution to the first match — without it,
+                    # sed would activate every '#KEY=...' example line, leaving
+                    # duplicate active entries that the webui save logic then
+                    # had to deduplicate on every subsequent save.
                     if sudo grep -q "^#\?${key}=" "$CONFIG_FILE" 2>/dev/null; then
-                        sudo sed -i "s|^#\?${key}=.*|${key}=${val}|" "$CONFIG_FILE"
+                        sudo sed -i "0,/^#\?${key}=/{s|^#\?${key}=.*|${key}=${val}|}" "$CONFIG_FILE"
                         migrated_keys="$migrated_keys $key"
                     fi
                 else

--- a/webui/config_parser.py
+++ b/webui/config_parser.py
@@ -46,9 +46,18 @@ class ShellVarConfig:
     def save(path, settings):
         """Rewrite config file, updating existing keys and preserving structure.
 
-        - Lines with existing keys are updated in place
-        - Comments and blank lines are preserved
-        - Keys not present in the file are appended at the end
+        - Active lines with known keys are updated in place (first occurrence only)
+        - Comments and blank lines are preserved unchanged
+        - Duplicate active key lines after the first are dropped (deduplication)
+        - Keys not present as active lines are appended at the end
+
+        Bug fixed (vs original): the original regex '^#?\\s*([A-Z_][A-Z0-9_]*)='
+        also matched commented-out example lines such as '#CPU_AUDIO=2', which
+        combined with install.sh's sed migration (which also activates those same
+        comment lines) produced duplicate active entries on every webui save.
+        Additionally, the missing 'key not in written_keys' guard meant that when
+        a key appeared more than once, every occurrence was rewritten — causing
+        exponential duplication across saves.
         """
         if os.path.exists(path):
             with open(path, 'r') as f:
@@ -61,11 +70,15 @@ class ShellVarConfig:
 
         for line in lines:
             stripped = line.strip()
-            # Match active or commented-out assignment
-            m = re.match(r'^#?\s*([A-Z_][A-Z0-9_]*)=', stripped)
+            # Only match active (non-commented) key=value assignments.
+            # Commented-out lines (e.g. example blocks like #CPU_AUDIO=2) are
+            # preserved unchanged — they must not be mistaken for active settings.
+            is_comment_or_blank = not stripped or stripped.startswith('#')
+            m = re.match(r'^([A-Z_][A-Z0-9_]*)=', stripped) if not is_comment_or_blank else None
             if m:
                 key = m.group(1)
-                if key in settings:
+                if key in settings and key not in written_keys:
+                    # First active occurrence of a known key → update value
                     val = settings[key]
                     # Quote values that are empty or contain special chars
                     if val == '' or re.search(r'[\s#\-]', val):
@@ -73,12 +86,14 @@ class ShellVarConfig:
                     else:
                         new_lines.append(f'{key}={val}\n')
                     written_keys.add(key)
+                elif key in written_keys:
+                    pass  # Duplicate active line → drop (deduplication)
                 else:
-                    new_lines.append(line)
+                    new_lines.append(line)  # Unknown key → preserve
             else:
-                new_lines.append(line)
+                new_lines.append(line)  # Comment, blank, or non-matching → preserve
 
-        # Append any new keys not already in the file
+        # Append any new keys not already present as active lines
         for key, val in settings.items():
             if key not in written_keys:
                 if val == '' or re.search(r'[\s#\-]', val):

--- a/webui/test_config_parser.py
+++ b/webui/test_config_parser.py
@@ -1,0 +1,126 @@
+"""Unit tests for ShellVarConfig.save() — regression coverage for the
+webui save-time deduplication and commented-line preservation fix.
+
+Run from the project root:
+    python3 webui/test_config_parser.py
+
+Or from webui/:
+    python3 -m unittest test_config_parser
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from config_parser import ShellVarConfig  # noqa: E402
+
+
+def _write(tmpdir, content):
+    path = os.path.join(tmpdir, "diretta-renderer.conf")
+    with open(path, "w") as f:
+        f.write(content)
+    return path
+
+
+def _read(path):
+    with open(path) as f:
+        return f.read()
+
+
+class TestShellVarConfigSave(unittest.TestCase):
+
+    def test_commented_example_lines_are_preserved(self):
+        """Commented-out example lines must not be mistaken for active settings.
+
+        Before the fix the regex '^#?\\s*...' would treat '#CPU_AUDIO=2'
+        as if it were 'CPU_AUDIO=2' and overwrite it, losing the example.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write(tmp, (
+                "# Example values for CPU_AUDIO:\n"
+                "#CPU_AUDIO=2\n"
+                "#CPU_AUDIO=3,4\n"
+                "CPU_AUDIO=\n"
+            ))
+            ShellVarConfig.save(path, {"CPU_AUDIO": "2"})
+            out = _read(path)
+
+            # The two commented example lines must still be present, unchanged.
+            self.assertIn("#CPU_AUDIO=2\n", out)
+            self.assertIn("#CPU_AUDIO=3,4\n", out)
+            # And the previously empty active line is now set.
+            self.assertIn("CPU_AUDIO=2\n", out)
+            # Exactly one ACTIVE assignment (regex strips leading '#').
+            active = [l for l in out.splitlines()
+                      if l.startswith("CPU_AUDIO=")]
+            self.assertEqual(active, ["CPU_AUDIO=2"])
+
+    def test_multiple_active_duplicates_are_collapsed(self):
+        """Pre-existing duplicate active lines (left behind by older webui
+        versions or by install.sh's sed migration) collapse to one."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write(tmp, (
+                "TARGET=1\n"
+                "CPU_AUDIO=2\n"
+                "CPU_AUDIO=2\n"
+                "CPU_AUDIO=2\n"
+                "PORT=4005\n"
+            ))
+            ShellVarConfig.save(path, {"CPU_AUDIO": "3"})
+            out = _read(path)
+            active = [l for l in out.splitlines()
+                      if l.startswith("CPU_AUDIO=")]
+            self.assertEqual(active, ["CPU_AUDIO=3"])
+            # Other keys are untouched.
+            self.assertIn("TARGET=1", out)
+            self.assertIn("PORT=4005", out)
+
+    def test_save_is_idempotent(self):
+        """Calling save() twice with the same settings produces the same file —
+        no exponential growth of any kind."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write(tmp, (
+                "# example\n"
+                "#CPU_AUDIO=2\n"
+                "CPU_AUDIO=\n"
+            ))
+            settings = {"CPU_AUDIO": "3"}
+            ShellVarConfig.save(path, settings)
+            once = _read(path)
+            ShellVarConfig.save(path, settings)
+            twice = _read(path)
+            self.assertEqual(once, twice)
+
+    def test_appends_new_key_when_absent(self):
+        """A key not present in the file is appended at the end."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = _write(tmp, "TARGET=1\n")
+            ShellVarConfig.save(path, {"TARGET": "1", "CPU_AUDIO": "2"})
+            out = _read(path)
+            self.assertIn("TARGET=1", out)
+            self.assertIn("CPU_AUDIO=2", out)
+
+    def test_comments_and_blanks_preserved(self):
+        """Comments and blank lines around assignments are preserved unchanged."""
+        with tempfile.TemporaryDirectory() as tmp:
+            original = (
+                "# Header comment\n"
+                "\n"
+                "TARGET=1\n"
+                "\n"
+                "# Trailing comment\n"
+            )
+            path = _write(tmp, original)
+            ShellVarConfig.save(path, {"TARGET": "2"})
+            out = _read(path)
+            self.assertIn("# Header comment\n", out)
+            self.assertIn("# Trailing comment\n", out)
+            self.assertIn("TARGET=2\n", out)
+            # Blank line between header and TARGET preserved.
+            self.assertIn("# Header comment\n\nTARGET=2\n", out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

`ShellVarConfig.save()` in the webui treated commented-out example
lines (e.g. `#CPU_AUDIO=2`) as if they were active settings, and
rewrote every occurrence of a key per save — so
`/etc/default/diretta-renderer` grew duplicate `KEY=VALUE` entries on
every webui save.

Two related changes plus a unit test:

- **`webui/config_parser.py`** — only match active (uncommented)
  assignment lines, update only the first occurrence per key, drop
  later active duplicates.
- **`install.sh`** — limit the migration sed to the first match per
  key with `0,/pattern/{s|...|}`. The old form activated every
  `#KEY=...` example line in the new config, which is the input the
  broken `save()` then mishandled.
- **`webui/test_config_parser.py`** — regression coverage (stdlib
  `unittest`, no new deps).

## How this was discovered

Investigating why `--cpu-other 0` thread-pinning failed on a
Raspberry Pi 4 setup. The pinning failure itself had a separate root
cause in `fedora-rpi-audiophile-setup` (follow-up PR planned there),
but `/etc/default/diretta-renderer` showing three identical
`CPU_AUDIO=2` lines after a single webui save turned out to be an
independent bug worth its own fix.

## Test plan

- [x] **Unit test** — 5/5 pass: commented-line preservation,
  duplicate collapse, idempotency, append-new-key, comment/blank
  preservation.
- [x] **Webui save cycle** on Fedora 44 / Raspberry Pi 4 — saves
  produce exactly one active line per key; repeated saves idempotent;
  `#KEY=...` example lines preserved.
- [x] **Fresh `install.sh`** on the same Pi via
  fedora-rpi-audiophile-setup — `/etc/default/diretta-renderer` ends
  up with 33 active keys, highest occurrence count is 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)