### PR TITLE
fix(tuner): include housekeeping CPU in slice; drop conflicting ExecStartPost

### DIFF
--- a/diretta-renderer-tuner-nosmt.sh
+++ b/diretta-renderer-tuner-nosmt.sh
@@ -245,8 +245,10 @@ Description=Slice for Diretta Renderer audio service (nosmt)
 Before=slices.target
 
 [Slice]
-# Pin to isolated audio cores (physical cores only, no SMT)
-AllowedCPUs=${RENDERER_CPUS}
+# Allow housekeeping + renderer cores; renderer cores stay
+# isolated via isolcpus on the kernel cmdline. DRUP pins its
+# own threads at thread level (--cpu-audio/--cpu-decode/--cpu-other).
+AllowedCPUs=${HOUSEKEEPING_CPUS},${RENDERER_CPUS}
 # Allow full CPU usage
 CPUQuota=100%
 EOF
@@ -380,9 +382,6 @@ LimitMEMLOCK=infinity
 
 # Real-time priority limit
 LimitRTPRIO=99
-
-# Distribute threads across physical cores after startup
-ExecStartPost=${THREAD_DIST_SCRIPT_PATH} \$MAINPID
 EOF
 
     echo "SUCCESS: Service override created: ${override_dir}/10-isolation.conf"

--- a/diretta-renderer-tuner.sh
+++ b/diretta-renderer-tuner.sh
@@ -314,8 +314,10 @@ Description=Slice for Diretta Renderer audio service
 Before=slices.target
 
 [Slice]
-# Pin to isolated audio cores
-AllowedCPUs=${RENDERER_CPUS}
+# Allow housekeeping + renderer cores; renderer cores stay
+# isolated via isolcpus on the kernel cmdline. DRUP pins its
+# own threads at thread level (--cpu-audio/--cpu-decode/--cpu-other).
+AllowedCPUs=${HOUSEKEEPING_CPUS},${RENDERER_CPUS}
 # Allow full CPU usage
 CPUQuota=100%
 EOF
@@ -350,9 +352,6 @@ LimitMEMLOCK=infinity
 
 # Real-time priority limit
 LimitRTPRIO=99
-
-# Distribute threads across cores after startup
-ExecStartPost=${THREAD_DIST_SCRIPT_PATH} \$MAINPID
 EOF
 
     echo "SUCCESS: Service override created: ${override_dir}/10-isolation.conf"


### PR DESCRIPTION
## Summary

The tuner's generated systemd slice set `AllowedCPUs=${RENDERER_CPUS}` — only renderer cores. On a 4-core Pi 4 that's `1-3`, blocking CPU 0 (housekeeping) from the cgroup cpuset. Combined with a follow-up `ExecStartPost=` that ran `distribute-diretta-threads.sh` round-robin, DRUP's own `--cpu-other` / `--cpu-audio` / `--cpu-decode` pinning (added in #68, v2.4.2) couldn't land — first because the cgroup forbade CPU 0, then because the post-start script overwrote whatever pinning DRUP had set.

Minimal fix in both tuner variants:

- `AllowedCPUs=${HOUSEKEEPING_CPUS},${RENDERER_CPUS}` — explicit union of both groups the tuner already defines. Mathematically equivalent to `0-N` on every system shape, but reads more clearly to a reviewer.
- Drop the `ExecStartPost=` line. `distribute-diretta-threads.sh` is still generated to `/usr/local/bin/` (backward compatibility for any external user invoking it manually), but the service unit no longer calls it.

Kernel cmdline isolation (`isolcpus` / `nohz_full` / `rcu_nocbs` / `irqaffinity`), the CPU governor service, and the NIC IRQ affinity script are all untouched.

## Relation to #75

[#75](https://github.com/cometdom/DirettaRendererUPnP/pull/75) described the follow-up landing in `cometdom/fedora-rpi-audiophile-setup`. Tracing the actual code path corrected that: the slice + service drop-in are generated by `diretta-renderer-tuner.sh` here in DRUP. `module 02-system-tuning.sh` of the wizard repo pins to a specific commit of this script (currently `ef025ef`) and runs it at install time. Hence the companion fix lands here, in DRUP.

## Impact across user shapes

- **With DRUP `--cpu-*` flags** (the modern flow): now works end-to-end. Previously impossible whenever any `--cpu-*` flag addressed CPU 0.
- **Without `--cpu-*` flags on a no-SMT system** (Pi 4): renderer threads may now also schedule onto CPU 0. In practice negligible — `isolcpus` still keeps system work off renderer cores.
- **Without `--cpu-*` flags on x86 with SMT**: same, plus the scheduler may also use SMT siblings of housekeeping cores (e.g. logical 12 on a 24-thread system). A subtle loosening of the "physical housekeeping core is sacrosanct" guarantee, accepted as the trade-off that enables the `--cpu-*` flow.

## Architectural note

The tuner still generates `distribute-diretta-threads.sh` on disk though we no longer invoke it. A follow-up could deprecate or remove that script entirely, and could optionally teach the tuner about DRUP's `--cpu-*` flags so its slice can express exact intent rather than "either of the two tuner-groups". Deliberately out of scope here.

## Test plan

- [x] **`bash -n`** passes on both `diretta-renderer-tuner.sh` and `diretta-renderer-tuner-nosmt.sh`.
- [x] **End-to-end on Fedora 44 / Raspberry Pi 4**: with `--cpu-other 0 --cpu-audio 2 --cpu-decode 3`, the `EINVAL` is gone, `ps -p $PID -L -o tid,psr,comm` shows other threads on CPU 0, audio thread on CPU 2, decode thread on CPU 3. No competing redistribution from `distribute-threads`.
- [ ] Not tested: no-SMT variant on bare metal (`diretta-renderer-tuner-nosmt.sh`). Edits to the two scripts are identical in shape, but I haven't booted with `nosmt` to confirm. Happy to leave that to a tester or skip if the reviewer is satisfied with the diff symmetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)