### PR TITLE
fix(build): never auto-select Zen4 variant without AVX-512 (Zen3 mobile SIGILL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [2.5.5] - 2026-06-18
+
+### Fixed
+- **Build: hard `SIGILL` (invalid opcode) on Zen3/Zen2 "Ryzen 7000" mobile CPUs** (reported by Didier/ds21 on a Topton FU02 / Ryzen 7 7730U). The Makefile's Zen4 auto-detection used a model-name regex (`Ryzen.*(5|7|9).*7[0-9]{3}…`) to select the SDK library variant. AMD's mobile branding reuses the "Ryzen 7000" *number* for older silicon — the Ryzen 7 7730U is Barcelo (Zen3, no AVX-512), the Ryzen 5 7520U is Mendocino (Zen2) — so those chips matched the Zen4 rule and got the `x64-linux-15zen4` SDK lib plus `-march=znver4`, both of which emit AVX-512 instructions the CPU cannot execute. The process core-dumped with `status=4/ILL` the instant the SDK's `DIRETTA::Connection` constructor ran (stack trace `#0 _ZN7DIRETTA10ConnectionC2Ev`), before any audio or network activity, and systemd restart-looped it indefinitely (restart counter observed at 830). The fallback AVX-512 feature check that would have caught this was only consulted when the model-name regex returned 0, so it never ran for these parts. Fix: a genuine Zen4 always has AVX-512, so a hard guard now forces `IS_ZEN4=0` whenever `/proc/cpuinfo` lacks the `avx512` flag — such CPUs correctly fall through to the AVX2 (`x64-linux-15v3`) variant. Real Zen4 (7700X etc.), Intel AVX-512 (→ `v4`), and plain AVX2 boxes (→ `v3`) are all unaffected. Existing wizard/`install.sh` users on an affected CPU just need to `git pull` and re-run `./install.sh` (or rebuild once with `make ARCH_NAME=x64-linux-15v3`).
+
 ## [2.5.4] - 2026-06-18
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,18 @@ ifeq ($(BASE_ARCH),x64)
         IS_ZEN4 := $(shell grep -q "avx512vbmi2" /proc/cpuinfo 2>/dev/null && grep -q "vaes" /proc/cpuinfo 2>/dev/null && echo 1 || echo 0)
     endif
 
+    # Hard guard: a genuine Zen4 ALWAYS has AVX-512. AMD's mobile branding
+    # reuses the "Ryzen 7000" number for Zen3/Zen2 silicon (e.g. Ryzen 7 7730U
+    # = Barcelo/Zen3, Ryzen 5 7520U = Mendocino/Zen2) which the model-name
+    # regex above wrongly matches. Without this guard those chips would select
+    # the zen4 SDK lib + -march=znver4 and crash with SIGILL (invalid opcode,
+    # AVX-512) the moment the SDK's DIRETTA::Connection constructor runs.
+    # Never treat a CPU lacking AVX-512 as Zen4. (Reported by Didier/ds21 on a
+    # Topton FU02 / Ryzen 7 7730U.)
+    ifeq ($(HAS_AVX512),0)
+        IS_ZEN4 := 0
+    endif
+
     ifeq ($(IS_ZEN4),1)
         DEFAULT_VARIANT = x64-linux-15zen4
     else ifeq ($(HAS_AVX512),1)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,7 @@
 #include <cerrno>
 #include <cstring>
 
-#define RENDERER_VERSION "2.5.4"
+#define RENDERER_VERSION "2.5.5"
 #define RENDERER_BUILD_DATE __DATE__
 #define RENDERER_BUILD_TIME __TIME__
 


### PR DESCRIPTION
## Summary

Fixes a hard `SIGILL` (invalid opcode) crash-loop on AMD **Zen3/Zen2 "Ryzen 7000" mobile** CPUs, reported by Didier/ds21 on a **Topton FU02 / Ryzen 7 7730U**.

The Makefile's Zen4 auto-detection matched the CPU **model-name** regex (`Ryzen.*(5|7|9).*7[0-9]{3}…`). AMD's mobile branding reuses the "Ryzen 7000" number for older silicon — the 7730U is **Barcelo (Zen3, no AVX-512)**, the 7520U is **Mendocino (Zen2)** — so these chips selected the `x64-linux-15zen4` SDK lib + `-march=znver4`, both emitting **AVX-512** the CPU can't execute.

Symptom: core-dump `status=4/ILL`, stack `#0 _ZN7DIRETTA10ConnectionC2Ev` (SDK `DIRETTA::Connection` constructor), before any audio/network, systemd restart-looping (counter at 830). `cpuinfo`: `avx2` present, **no `avx512`**.

The existing AVX-512 fallback check never ran here because it was gated behind `ifeq ($(IS_ZEN4),0)` and the model-name regex already returned 1.

## Fix

A genuine Zen4 always has AVX-512. Add a hard guard: force `IS_ZEN4=0` whenever `/proc/cpuinfo` lacks `avx512`. Affected CPUs fall through to the AVX2 `x64-linux-15v3` variant.

| CPU | before | after |
|---|---|---|
| Ryzen 7 7730U (Zen3) | zen4 → **SIGILL** | **v3 (AVX2)** |
| Ryzen 7 7700X (Zen4) | zen4 | zen4 |
| Intel AVX-512 | v4 | v4 |
| AVX2 generic | v3 | v3 |

## Propagation

The setup wizards `git clone` DRUP's `main` (not a tag), so merging this fixes all future wizard installs immediately. Existing affected installs: `git pull && ./install.sh`, or one-off `make ARCH_NAME=x64-linux-15v3`.

## Test plan

- [x] `make info` parses; variant selection simulated for the four CPU classes above.
- [ ] Confirmation on Didier's 7730U (in progress via the manual `ARCH_NAME=x64-linux-15v3` workaround).

🤖 Generated with [Claude Code](https://claude.com/claude-code)