### PR TITLE
fix(boot): defensive Target reset after warmup to escape stale idle-mode

### DIFF
--- a/src/DirettaRenderer.cpp
+++ b/src/DirettaRenderer.cpp
@@ -307,7 +307,15 @@ bool DirettaRenderer::start(std::atomic<bool>* stopSignal) {
             std::cout << "[DirettaRenderer] Pre-connecting Diretta (warmup)..." << std::endl;
             if (m_direttaSync->open(warmupFmt)) {
                 m_direttaSync->stopPlayback(true);
-                std::cout << "[DirettaRenderer] Diretta pre-connected (warmup done)" << std::endl;
+
+                // Hold the SDK connection long enough for the Diretta Target to exit
+                // a stale idle-mode before we close, then leave it closed — the first
+                // real play will pay the cold-connect cost again, but the boot ends
+                // with Target in a usable state instead of stuck-claiming.
+                std::this_thread::sleep_for(std::chrono::seconds(6));
+                m_direttaSync->release();
+
+                std::cout << "[DirettaRenderer] Diretta warmup + target reset complete" << std::endl;
             } else {
                 std::cerr << "[DirettaRenderer] Warmup pre-connect failed (non-fatal)" << std::endl;
             }


### PR DESCRIPTION
## Summary

A Diretta Target that's been idle for several minutes before DRUP starts
can enter a stuck idle-mode where it accepts the SDK connection but never
reaches a streaming-capable state. Symptom: fast Target LEDs after boot,
no UPnP renderer can claim Target until an external UPnP `AVTransport:Stop`
on DRUP triggers the idle release timer (~5s) which calls `release()`.

This PR holds the existing boot warmup SDK connection for 6 seconds, then
fully releases it. The hold gives Target time to exit its stuck mode and
the release gives Target a clean session-end.

## Root cause investigation

Diagnostic test series (logged across multiple boot scenarios, slim2UPnP
intentionally killed on the upstream server to isolate from auto-rescue):

| Test | Setup | Stuck state? |
|---|---|---|
| `sudo reboot` (~30s downtime, same SD) | Same OS | ❌ No |
| `shutdown -h now` + 2-min wait + power | Same OS, same SD | ✅ Yes |
| Same as above, slim2UPnP killed on server | Same SD | ✅ Yes |
| Both Host+Target off, Target fresh boot, 2-min Target idle, then Host on | Target had no prior client this session | ✅ Yes |
| Both off, Target on, Host on immediately | Control | ❌ No |

So the bug triggers whenever Target has been idle for more than some
threshold (~minutes) before DRUP connects. Independent of OS, of SD-swap,
of predecessor shutdown cleanliness, and of whether Target had a prior
client this session. The root cause is most likely a state-machine bug
in the Target firmware / Diretta SDK on the Target side (we lack source
access to either to confirm), but a fully client-side workaround is
appropriate since DRUP cannot rely on every Target firmware behaving
the same way.

## Mechanism of the fix

The previous warmup (commit `0d1279b`) did:
```cpp
open(warmupFmt) → stopPlayback(true)
```
Which left the SDK connection open after boot. If Target was in the
stuck mode when we connected, the warmup just trapped us in it.

This PR changes it to:
```cpp
open(warmupFmt) → stopPlayback(true) → sleep 6s → release()
```
The 6-second active connection followed by a clean SDK close lets
Target exit the stuck mode. The first real play then does a fresh
cold connect.

## Trade-offs

- Boot is ~6 seconds longer (the deliberate hold).
- The first real play pays a small cold-connect cost again
  (~500ms-2.5s observed in testing, well under the ~5s glitch the
  original warmup was designed to prevent — possibly the SDK is faster
  on newer versions, or the original glitch was measured under
  different conditions).
- All other playback paths (track changes, quick-resume on same
  format, idle release timer, renderer switching) behave as before.

## Verification

Pi 4 + GentooPlayer Diretta Target on SDK 1.48.

Test: power off both Host and Target. Power on Target. Wait 2+ minutes.
Power on Host with this patch. Observe Target LEDs and runtime log.

Expected (and observed):
```
[DirettaRenderer] Pre-connecting Diretta (warmup)...
[DirettaSync] OPEN COMPLETE
[6 seconds elapse — Target settles out of stuck mode]
[DirettaSync] Release() - fully releasing target
[DirettaRenderer] Diretta warmup + target reset complete
```

LEDs: briefly fast during the 6-second hold, then continuous (steady).
Without the fix on the same hardware/scenario: LEDs blink fast
indefinitely, no UPnP renderer can claim Target.

Playback paths re-verified after the fix:
- First play (Roon → slim2UPnP → DRUP): ~500ms cold connect, then plays.
- Same-format track change: instant quick-resume path used.
- Renderer switch (DRUP ↔ slim2Diretta in Roon): works, Target released
  and re-claimed normally.
- 5-second idle release timer: still fires after stop, releases Target.

## Alternatives considered

- **Just remove the warmup**: would re-introduce the ~5s first-play glitch
  that motivated commit `0d1279b`. Rejected.
- **Warmup + release + re-warmup (no hold)**: tested in an earlier iteration
  but Target gets re-trapped in the stuck mode by the immediate reopen.
  Rejected.
- **Shorter than 6-second hold**: not tested for minimum threshold; 6 seconds
  was chosen because it matches the timing of the slim2UPnP-rerun fix that
  was already known to work (initial SOAP probe + 5s \`m_idleTimerActive\`).
  Could be optimized in a follow-up if boot-time delay is a concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)