### PR TITLE
feat: bypass decoder for bit-perfect raw packet passthrough

### DIFF
--- a/src/AudioEngine.cpp
+++ b/src/AudioEngine.cpp
@@ -111,6 +111,7 @@ bool AudioDecoder::open(const std::string& url) {
     std::cout << "[AudioDecoder] Opening: " << url.substr(0, 80) << "..." << std::endl;
     m_decodeError = false;
     m_readTimeout = false;
+    m_rawPacketBypass = false;
 
     // Open input file
     m_formatContext = avformat_alloc_context();
@@ -1407,6 +1408,30 @@ size_t AudioDecoder::readSamples(AudioBuffer& buffer, size_t numSamples,
             continue;
         }
 
+        // RAW PACKET BYPASS: copy packet data directly, skip codec entirely.
+        // Safe only when raw bytes/frame == output bytes/frame (detected in initResampler).
+        // Truncated packets (e.g. < 1 complete sample) are silently discarded — no error.
+        if (m_rawPacketBypass) {
+            size_t packetSamples = (size_t)m_packet->size / bytesPerSample;
+            if (packetSamples > 0) {
+                size_t samplesToCopy = std::min(packetSamples, numSamples - totalSamplesRead);
+                size_t bytesToCopy   = samplesToCopy * bytesPerSample;
+                memcpy_audio(outputPtr, m_packet->data, bytesToCopy);
+                outputPtr        += bytesToCopy;
+                totalSamplesRead += samplesToCopy;
+                m_liveStreamDecodeErrors = 0;
+
+                if (packetSamples > samplesToCopy && m_pcmFifo) {
+                    uint8_t* excessPtr     = m_packet->data + bytesToCopy;
+                    uint8_t* excessPtrs[1] = { excessPtr };
+                    av_audio_fifo_write(m_pcmFifo, (void**)excessPtrs,
+                                        (int)(packetSamples - samplesToCopy));
+                }
+            }
+            av_packet_unref(m_packet);
+            continue;
+        }
+
         // Send packet to decoder
         ret = avcodec_send_packet(m_codecContext, m_packet);
         av_packet_unref(m_packet);
@@ -1661,11 +1686,28 @@ bool AudioDecoder::initResampler(uint32_t outputRate, uint32_t outputBits) {
         }
 
         m_bypassMode = true;
+
+        // Detect raw packet bypass: safe when raw bytes/frame == output bytes/frame
+        // (little-endian only — big-endian codecs require a byte swap the codec provides)
+        {
+            AVCodecID id = m_codecContext->codec_id;
+            bool isLE = (id == AV_CODEC_ID_PCM_S16LE ||
+                         id == AV_CODEC_ID_PCM_S24LE ||
+                         id == AV_CODEC_ID_PCM_S32LE);
+            int rawBytesPerFrame  = m_codecContext->block_align;
+            int outBytesPerFrame  = (int)(((outputBits == 16) ? 2 : 4) * m_trackInfo.channels);
+            m_rawPacketBypass = isLE && (rawBytesPerFrame == outBytesPerFrame);
+            if (m_rawPacketBypass) {
+                std::cout << "[AudioDecoder] RAW PACKET BYPASS enabled - codec completely skipped" << std::endl;
+            }
+        }
+
         m_resamplerInitialized = true;
         return true;
     }
 
     m_bypassMode = false;
+    m_rawPacketBypass = false;
 
     // Free existing resampler
     if (m_swrContext) {

--- a/src/AudioEngine.cpp
+++ b/src/AudioEngine.cpp
@@ -1419,13 +1419,15 @@ size_t AudioDecoder::readSamples(AudioBuffer& buffer, size_t numSamples,
                 memcpy_audio(outputPtr, m_packet->data, bytesToCopy);
                 outputPtr        += bytesToCopy;
                 totalSamplesRead += samplesToCopy;
-                m_liveStreamDecodeErrors = 0;
 
                 if (packetSamples > samplesToCopy && m_pcmFifo) {
                     uint8_t* excessPtr     = m_packet->data + bytesToCopy;
                     uint8_t* excessPtrs[1] = { excessPtr };
-                    av_audio_fifo_write(m_pcmFifo, (void**)excessPtrs,
-                                        (int)(packetSamples - samplesToCopy));
+                    int written = av_audio_fifo_write(m_pcmFifo, (void**)excessPtrs,
+                                                     (int)(packetSamples - samplesToCopy));
+                    if (written < 0) {
+                        std::cerr << "[AudioDecoder] FIFO write failed in bypass path, excess samples dropped" << std::endl;
+                    }
                 }
             }
             av_packet_unref(m_packet);
@@ -1691,6 +1693,8 @@ bool AudioDecoder::initResampler(uint32_t outputRate, uint32_t outputBits) {
         // (little-endian only — big-endian codecs require a byte swap the codec provides)
         {
             AVCodecID id = m_codecContext->codec_id;
+            // S24LE is listed for completeness but cannot activate bypass:
+            // block_align=channels*3 never equals outBytesPerFrame=channels*4.
             bool isLE = (id == AV_CODEC_ID_PCM_S16LE ||
                          id == AV_CODEC_ID_PCM_S24LE ||
                          id == AV_CODEC_ID_PCM_S32LE);

--- a/src/AudioEngine.h
+++ b/src/AudioEngine.h
@@ -208,6 +208,9 @@ private:
     // Enables bit-perfect playback for matching integer formats
     bool m_bypassMode = false;
     bool m_resamplerInitialized = false;
+    // Raw packet bypass - skip codec entirely when raw bytes == output bytes
+    // (little-endian PCM, no expansion or byte-swap needed)
+    bool m_rawPacketBypass = false;
 
     // D2: Cached resampler delay (avoids swr_get_delay() call every frame)
     // Delay stabilizes after first few frames, refresh periodically


### PR DESCRIPTION
## Summary

- Detects when the incoming PCM stream is already in the exact output format (`block_align == outBytesPerFrame`, little-endian only)
- In that case, copies raw packet bytes directly into the audio path, skipping `avcodec_send_packet()` / `avcodec_receive_frame()` entirely
- Falls back to the normal decode path for all other formats (big-endian, compressed, mismatched frame size)

## Motivation

For native PCM streams (e.g. `pcm_s16le`) the FFmpeg decode step is a no-op that adds latency and CPU overhead. Bypassing it gives bit-perfect passthrough with zero decode overhead.

## Independence

This fix is independent of the live-stream reconnect fixes (PR #84 / PR #85). It activates only on PCM streams where `block_align == outBytesPerFrame` and is completely inert for all other formats.

## Test plan

- [x] Verified `RAW PACKET BYPASS enabled - codec completely skipped` appears in log for `pcm_s16le` (44100Hz/16bit/2ch)
- [x] Verified bypass does NOT activate for `pcm_s24le` (block_align 6 ≠ outBytesPerFrame 8)
- [x] Verified audio plays correctly via bit-perfect bypass path

🤖 Generated with [Claude Code](https://claude.com/claude-code)