### PR TITLE
Fix SDK 150.x ~50s connection stall (Yu Harada)

### DIFF
--- a/src/DirettaSync.cpp
+++ b/src/DirettaSync.cpp
@@ -790,6 +790,12 @@ bool DirettaSync::open(const AudioFormat& format) {
         return false;
     }
 
+    // Apply the sink format determined earlier by configureSinkPCM()/
+    // configureSinkDSD() — deferred until now because setSinkConfigure()
+    // must be called AFTER setSink(), not before (see m_pendingSinkFormat's
+    // doc comment; Yu Harada, 2026-09-06).
+    setSinkConfigure(m_pendingSinkFormat);
+
     // SDK 148: Query format support after setSink to initialize internal structures
     // This may be required for stream objects to be properly allocated
     if (needFullConnect) {
@@ -1049,7 +1055,9 @@ void DirettaSync::configureSinkPCM(int rate, int channels, int inputBits, int& a
     if (inputBits >= 32) {
         fmt.setFormat(DIRETTA::FormatID::FMT_PCM_SIGNED_32);
         if (checkSinkSupport(fmt)) {
-            setSinkConfigure(fmt);
+            // Stashed, not applied yet — setSinkConfigure() must be called AFTER
+        // setSink(), not before (see m_pendingSinkFormat's doc comment).
+        m_pendingSinkFormat = fmt;
             acceptedBits = 32;
             DIRETTA_LOG("Sink PCM: " << rate << "Hz " << channels << "ch 32-bit");
             return;
@@ -1058,7 +1066,9 @@ void DirettaSync::configureSinkPCM(int rate, int channels, int inputBits, int& a
 
     fmt.setFormat(DIRETTA::FormatID::FMT_PCM_SIGNED_24);
     if (checkSinkSupport(fmt)) {
-        setSinkConfigure(fmt);
+        // Stashed, not applied yet — setSinkConfigure() must be called AFTER
+        // setSink(), not before (see m_pendingSinkFormat's doc comment).
+        m_pendingSinkFormat = fmt;
         acceptedBits = 24;
         DIRETTA_LOG("Sink PCM: " << rate << "Hz " << channels << "ch 24-bit");
         return;
@@ -1066,7 +1076,9 @@ void DirettaSync::configureSinkPCM(int rate, int channels, int inputBits, int& a
 
     fmt.setFormat(DIRETTA::FormatID::FMT_PCM_SIGNED_16);
     if (checkSinkSupport(fmt)) {
-        setSinkConfigure(fmt);
+        // Stashed, not applied yet — setSinkConfigure() must be called AFTER
+        // setSink(), not before (see m_pendingSinkFormat's doc comment).
+        m_pendingSinkFormat = fmt;
         acceptedBits = 16;
         DIRETTA_LOG("Sink PCM: " << rate << "Hz " << channels << "ch 16-bit");
         return;
@@ -1099,7 +1111,9 @@ void DirettaSync::configureSinkDSD(uint32_t dsdBitRate, int channels, const Audi
                   DIRETTA::FormatID::FMT_DSD_LSB |
                   DIRETTA::FormatID::FMT_DSD_BIG);
     if (checkSinkSupport(fmt)) {
-        setSinkConfigure(fmt);
+        // Stashed, not applied yet — setSinkConfigure() must be called AFTER
+        // setSink(), not before (see m_pendingSinkFormat's doc comment).
+        m_pendingSinkFormat = fmt;
         m_needDsdBitReversal.store(!sourceIsLSB, std::memory_order_release);  // Reverse if source is MSB (DFF)
         m_needDsdByteSwap.store(false, std::memory_order_release);  // BIG endian = no swap
         // Set cached conversion mode: no swap, maybe bit reverse
@@ -1118,7 +1132,9 @@ void DirettaSync::configureSinkDSD(uint32_t dsdBitRate, int channels, const Audi
                   DIRETTA::FormatID::FMT_DSD_MSB |
                   DIRETTA::FormatID::FMT_DSD_BIG);
     if (checkSinkSupport(fmt)) {
-        setSinkConfigure(fmt);
+        // Stashed, not applied yet — setSinkConfigure() must be called AFTER
+        // setSink(), not before (see m_pendingSinkFormat's doc comment).
+        m_pendingSinkFormat = fmt;
         m_needDsdBitReversal.store(sourceIsLSB, std::memory_order_release);  // Reverse if source is LSB (DSF)
         m_needDsdByteSwap.store(false, std::memory_order_release);  // BIG endian = no swap
         // Set cached conversion mode: no swap, maybe bit reverse
@@ -1137,7 +1153,9 @@ void DirettaSync::configureSinkDSD(uint32_t dsdBitRate, int channels, const Audi
                   DIRETTA::FormatID::FMT_DSD_LSB |
                   DIRETTA::FormatID::FMT_DSD_LITTLE);
     if (checkSinkSupport(fmt)) {
-        setSinkConfigure(fmt);
+        // Stashed, not applied yet — setSinkConfigure() must be called AFTER
+        // setSink(), not before (see m_pendingSinkFormat's doc comment).
+        m_pendingSinkFormat = fmt;
         m_needDsdBitReversal.store(!sourceIsLSB, std::memory_order_release);
         m_needDsdByteSwap.store(true, std::memory_order_release);  // LITTLE endian = swap bytes
         // Set cached conversion mode: always swap, maybe bit reverse
@@ -1156,7 +1174,9 @@ void DirettaSync::configureSinkDSD(uint32_t dsdBitRate, int channels, const Audi
                   DIRETTA::FormatID::FMT_DSD_MSB |
                   DIRETTA::FormatID::FMT_DSD_LITTLE);
     if (checkSinkSupport(fmt)) {
-        setSinkConfigure(fmt);
+        // Stashed, not applied yet — setSinkConfigure() must be called AFTER
+        // setSink(), not before (see m_pendingSinkFormat's doc comment).
+        m_pendingSinkFormat = fmt;
         m_needDsdBitReversal.store(sourceIsLSB, std::memory_order_release);
         m_needDsdByteSwap.store(true, std::memory_order_release);  // LITTLE endian = swap bytes
         // Set cached conversion mode: always swap, maybe bit reverse
@@ -1172,7 +1192,9 @@ void DirettaSync::configureSinkDSD(uint32_t dsdBitRate, int channels, const Audi
     // Last resort - assume LSB | BIG target
     fmt.setFormat(DIRETTA::FormatID::FMT_DSD1);
     if (checkSinkSupport(fmt)) {
-        setSinkConfigure(fmt);
+        // Stashed, not applied yet — setSinkConfigure() must be called AFTER
+        // setSink(), not before (see m_pendingSinkFormat's doc comment).
+        m_pendingSinkFormat = fmt;
         m_needDsdBitReversal.store(!sourceIsLSB, std::memory_order_release);
         m_needDsdByteSwap.store(false, std::memory_order_release);
         DIRETTA_LOG("Sink DSD: FMT_DSD1 only"

--- a/src/DirettaSync.h
+++ b/src/DirettaSync.h
@@ -523,7 +523,16 @@ protected:
     bool getNewStream(diretta_stream& stream) override;
     bool getNewStreamCmp() override { return true; }
     bool startSyncWorker() override;
-    void statusUpdate() override {}
+
+    // Was an empty stub — Yu Harada (2026-09-06): "If you are handling
+    // statusUpdate in a derived class, be sure to call the statusUpdate
+    // method of the base class. Otherwise, the notification will not reach
+    // ConnectWait." Confirmed by a packet capture during a live stall: the
+    // actual UDP negotiation with the target completes and streams normally
+    // within ~1s, continuously, for the full ~50s+ duration — connectWait()
+    // was simply never being woken up despite the connection already being
+    // good, and sitting out its full internal timeout every time.
+    void statusUpdate() override { DIRETTA::Sync::statusUpdate(); }
 
 private:
     //=========================================================================

--- a/src/DirettaSync.h
+++ b/src/DirettaSync.h
@@ -576,6 +576,21 @@ private:
     uint32_t m_mtuOverride = 0;
     uint32_t m_effectiveMTU = 1500;
 
+    // The format configureSinkPCM()/configureSinkDSD() determined is
+    // supported (via checkSinkSupport()'s trial-and-error), stashed here so
+    // open() can call setSinkConfigure() with it AFTER setSink() — Yu Harada
+    // (2026-09-06): "It is assumed that Sync::setSinkConfigure is always
+    // called after Sync::setSink... I fixed an issue where [an] internal
+    // flag was not being initialized by Sync::setSink, and have now
+    // initialized it. Therefore, if you call Sync::setSink, you must also
+    // call Sync::setSinkConfigure; otherwise, the behavior will be
+    // unpredictable." We called setSinkConfigure() BEFORE setSink() (see
+    // open()'s history), which SDK 149's uninitialized-flag bug tolerated;
+    // SDK 150 fixed that flag, exposing the wrong order as the ~50s
+    // connectWait() stall / outright setSink failures. See
+    // tune-diretta-hardware-test-rig memory note for the full writeup.
+    DIRETTA::FormatConfigure m_pendingSinkFormat;
+
     // Connection state
     std::atomic<bool> m_enabled{false};      // Target discovered, ready to use
     std::atomic<bool> m_sdkOpen{false};      // SDK-level connection open

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,6 +11,7 @@
 #include "DirettaSync.h"
 #include "LogLevel.h"
 #include "TimestampedLogger.h"
+#include <SysLog.hpp>
 #include <iostream>
 #include <csignal>
 #include <memory>
@@ -433,6 +434,20 @@ int main(int argc, char* argv[]) {
     signal(SIGINT, signalHandler);
     signal(SIGTERM, signalHandler);
     signal(SIGUSR1, statsSignalHandler);
+
+    // DIRETTA_SDK_SYSLOG_DEBUG=1 turns on the SDK's own internal syslog
+    // output (DIRETTA::SysLogDiretta, Host/SysLog.hpp) at Debug level,
+    // printed straight to stdout (so it lands in this process's own logs
+    // alongside everything else) — never enabled before now. Added while
+    // investigating the SDK 150.x connection stall at Yu Harada's request
+    // ("Is it possible to capture logs from DirettaHost?"). Off by default:
+    // untested verbosity/performance impact, no reason to enable in normal
+    // use.
+    if (std::getenv("DIRETTA_SDK_SYSLOG_DEBUG")) {
+        DIRETTA::SysLogDiretta::initialize(ACQUA::SysLog::user, 0, true);
+        DIRETTA::SysLogDiretta::changeLevel(ACQUA::SysLog::Debug, 0);
+        std::cout << "[main] Diretta SDK internal syslog enabled (Debug level, stdout)" << std::endl;
+    }
 
     // SIGINT/SIGTERM are never blocked on the main thread — it must stay the
     // sole, always-interruptible receiver of a process-directed signal,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -436,17 +436,21 @@ int main(int argc, char* argv[]) {
     signal(SIGUSR1, statsSignalHandler);
 
     // DIRETTA_SDK_SYSLOG_DEBUG=1 turns on the SDK's own internal syslog
-    // output (DIRETTA::SysLogDiretta, Host/SysLog.hpp) at Debug level,
-    // printed straight to stdout (so it lands in this process's own logs
-    // alongside everything else) — never enabled before now. Added while
-    // investigating the SDK 150.x connection stall at Yu Harada's request
-    // ("Is it possible to capture logs from DirettaHost?"). Off by default:
-    // untested verbosity/performance impact, no reason to enable in normal
-    // use.
+    // output (DIRETTA::SysLogDiretta, Host/SysLog.hpp) at Debug level —
+    // never enabled before now. Added while investigating the SDK 150.x
+    // connection stall at Yu Harada's request ("Is it possible to capture
+    // logs from DirettaHost?"). Off by default: untested verbosity/
+    // performance impact, no reason to enable in normal use.
+    //
+    // The `st` param's doc comment ("true: stdout output enabled (is false
+    // direct to stdout)") is self-contradictory in the shipped header — a
+    // first attempt with `true` produced no extra output at all (confirmed
+    // we ARE linking the logging-capable library variant, not -nolog, so
+    // this isn't a missing-symbols issue). Trying `false` here instead.
     if (std::getenv("DIRETTA_SDK_SYSLOG_DEBUG")) {
-        DIRETTA::SysLogDiretta::initialize(ACQUA::SysLog::user, 0, true);
+        DIRETTA::SysLogDiretta::initialize(ACQUA::SysLog::user, 0, false);
         DIRETTA::SysLogDiretta::changeLevel(ACQUA::SysLog::Debug, 0);
-        std::cout << "[main] Diretta SDK internal syslog enabled (Debug level, stdout)" << std::endl;
+        std::cout << "[main] Diretta SDK internal syslog enabled (Debug level, st=false)" << std::endl;
     }
 
     // SIGINT/SIGTERM are never blocked on the main thread — it must stay the


### PR DESCRIPTION
## Summary

Fixes the ~50s connection-establishment stall (and outright "Failed to set sink" failures) reported against Diretta Host SDK 150.x. Confirmed working on real hardware — `OPEN` → `OPEN COMPLETE` now completes in well under a second, matching SDK 149.x behavior, both on the boot warmup and on real playback.

Two distinct bugs, both identified by Yu Harada while diagnosing the bug report:

1. **`statusUpdate()` override was an empty stub** (`void statusUpdate() override {}`), silently swallowing the base class's notification that `connectWait()` waits on. This is the actual root cause of the stall — confirmed via a live packet capture during a stall: the real UDP negotiation with the target completed and streamed normally within ~1s the entire time; `connectWait()` was simply never woken up despite the connection already being good. Fixed by chaining to `DIRETTA::Sync::statusUpdate()`.

2. **`configureSinkPCM()`/`configureSinkDSD()` called `setSinkConfigure()` before `setSink()`** — the wrong order per Yu's explicit guidance ("if you call `Sync::setSink`, you must also call `Sync::setSinkConfigure`" — after, not before). SDK 149's own uninitialized-flag bug apparently tolerated this; SDK 150 fixed that flag, exposing the wrong order. This one didn't turn out to be the cause of the reported stall (tested in isolation, no effect), but it's a real correctness bug per the SDK author and worth keeping fixed. Deferred via a new `m_pendingSinkFormat` member, applied once right after `setSink()` succeeds.

Also includes a `DIRETTA_SDK_SYSLOG_DEBUG=1` env var enabling the SDK's own internal syslog output (`DIRETTA::SysLogDiretta`), added while investigating — kept since it may be useful diagnostic tooling later, off by default.

## Test plan

- [x] Builds clean
- [x] Confirmed on real hardware (SDK 150_4, DDC-0 target firmware 150_1): warmup and real playback both connect in <1s, repeated restarts, `Stop` during playback transitions cleanly (`PLAYING → STOPPED`, not "ignored")

🤖 Generated with [Claude Code](https://claude.com/claude-code)