### PR TITLE
fix: build on SDK 149 — is_MSmode() only exists in SDK 150

### DIFF
--- a/src/DirettaSync.cpp
+++ b/src/DirettaSync.cpp
@@ -99,6 +99,25 @@ static bool sdkConnect(S& sync, int cpu, bool rapidStart) {
     }
 }
 
+// SDK 150 also added Sync::is_MSmode(); SDK 149 has no such accessor.
+// Same compile-time resolution: log the negotiated MS mode when the SDK
+// exposes it, "n/a" otherwise, instead of failing the build on SDK 149.
+template <typename S, typename = void>
+struct SdkHasIsMSmode : std::false_type {};
+template <typename S>
+struct SdkHasIsMSmode<S, std::void_t<decltype(std::declval<S&>().is_MSmode())>>
+    : std::true_type {};
+
+template <typename S>
+static std::string sdkMSmodeString(S& sync) {
+    if constexpr (SdkHasIsMSmode<S>::value) {
+        return std::to_string(static_cast<int>(sync.is_MSmode()));
+    } else {
+        (void)sync;
+        return "n/a";
+    }
+}
+
 class RingAccessGuard {
 public:
     RingAccessGuard(std::atomic<int>& users, const std::atomic<bool>& reconfiguring)
@@ -2402,7 +2421,7 @@ void DirettaSync::logNegotiatedProfile(const char* when) {
              << " cycleSize=" << getCycleSize() << "B"
              << " packets/cycle=" << getCyclePackets()
              << " mode=" << modeName
-             << " msMode=" << static_cast<int>(is_MSmode())
+             << " msMode=" << sdkMSmodeString(static_cast<DIRETTA::Sync&>(*this))
              << " latency=" << getLatency().getMicroSeconds() << "us"
              << " sink{latencyBuffer=" << info.latencyBuffer
              << " latencyMax=" << info.latencyMax


### PR DESCRIPTION
## Problem

Building v2.5.17 against `DirettaHostSDK_149` fails (reported on Fedora via `fedora-audiophile-setup` option 12, clang/`LLVM=1` build):

```
src/DirettaSync.cpp:2405:48: error: use of undeclared identifier 'is_MSmode'
2405 |              << " msMode=" << static_cast<int>(is_MSmode())
```

`DirettaSync::logNegotiatedProfile()` (added in PR #94) calls `Sync::is_MSmode()` unconditionally, but that accessor only exists in SDK 150. Every other getter in that log line (`getCyclePackets`, `getMinCycleTime`, `getLatency`, `getSinkInfo`) is available in SDK 149, so this is the single blocker. The CLAUDE.md contract is that SDK 149 keeps building.

## Fix

Resolve the accessor at compile time with the same SFINAE pattern already used for `connect(int, bool)` (`SdkHasRapidStart`):

- new `SdkHasIsMSmode<S>` trait + `sdkMSmodeString()` helper next to `sdkConnect()`
- `logNegotiatedProfile()` logs the real value on SDK 150 and `n/a` on SDK 149

No behaviour change on the audio path; only the diagnostic log line is affected.

## Verification

- The SDK is not available in the CI environment where this was written, so the full file was not compiled there. The SFINAE helper was compiled and run in isolation against two mock classes (one with `is_MSmode()`, one without) with both `g++` and `clang++ -std=c++17 -Wall -Wextra`: prints `n/a` and `1` respectively.
- Please confirm on a real SDK 149 host with `sudo ./setup.sh --only install-drup` (or `make LLVM=1`).

The 18 remaining warnings in the reporter's output are unrelated: the `-Wignored-qualifiers` ones come from the SDK's own `Receive.hpp` under clang, the rest are pre-existing unused variables.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017n6naEwNTsJwEEqXcFYrZk

---
_Generated by [Claude Code](https://claude.ai/code/session_017n6naEwNTsJwEEqXcFYrZk)_